### PR TITLE
Two fixes

### DIFF
--- a/systemd-swap.sh
+++ b/systemd-swap.sh
@@ -109,7 +109,7 @@ parse_config(){
   if [ ! -z ${swapd[parse]} ]; then
      swapd[devs]=" `blkid -t TYPE=swap -o device | grep -vE '(zram|loop)'`
                    ${swapd[devs]}"
-     [ ! -z ${swapf[Poff]} ] && [ ! -z "${swapd[devs]}" ] && unset swapf
+     [ ! -z ${swapf[Poff]} ] && [ ! -z "${swapd[devs]}" ] && unset swapf || true
   fi
 }
 


### PR DESCRIPTION
- The script will stop running if ${swapf[Poff]} is not set. I've dig into it a bit, and find the offending line:

```
[ ! -z ${swapf[Poff]} ] && [ ! -z "${swapd[devs]}" ] && unset swapf
```

so if ${swapf[Poff]} not set, it will be treated as an error, and preventing the rest of the script from executing. The -x output stops here:

```
+ swapd[devs]='/dev/sde1 '
+ '[' '!' -z ']'
```
- While switching to max_comp_streams, the unit "K" is missing. The ${sys[ram_size]} still remains in the same unit (K), so manage_zram always create a mini zram swap device. Adding the missing K fixes this.
