### PR TITLE
Fix: don't fail when there's no swapd

### DIFF
--- a/systemd-swap.sh
+++ b/systemd-swap.sh
@@ -107,9 +107,9 @@ parse_config(){
   fi
 
   if [ ! -z ${swapd[parse]} ]; then
-     swapd[devs]=" `blkid -t TYPE=swap -o device | grep -vE '(zram|loop)'`
+     swapd[devs]=" `blkid -t TYPE=swap -o device | grep -vE '(zram|loop)' || :`
                    ${swapd[devs]}"
-     [ ! -z ${swapf[Poff]} ] && [ ! -z "${swapd[devs]}" ] && unset swapf || true
+     [ ! -z ${swapf[Poff]} ] && [ ! -z "${swapd[devs]}" ] && unset swapf || :
   fi
 }
 


### PR DESCRIPTION
```
blkid -t TYPE=swap -o device
```

Will return "2" if there's no swap device, thus the script stops here. Adding `|| :` like others will work it out.
