### PR TITLE
fix 90-systemd-swap.conf so the comment will not be treated as params by modprobe

### DIFF
--- a/90-systemd-swap.conf
+++ b/90-systemd-swap.conf
@@ -1,4 +1,4 @@
 # Need to rework zram. I think zram will be better if new devices can be added
 # on demand, like loop.
-# This hardcoded for simplify code.
-options zram num_devices=32 #32 is max zram devices
+# 32 is the max number of zram devices, which is hardcoded to simplify code.
+options zram num_devices=32


### PR DESCRIPTION
This doesn't cause an error, but should be fixed so we don't get annoying logs like these:

```
[    4.398682] zram: unknown parameter '#32' ignored
[    4.398685] zram: unknown parameter 'is' ignored
[    4.398686] zram: unknown parameter 'max' ignored
[    4.398687] zram: unknown parameter 'zram' ignored
[    4.398688] zram: unknown parameter 'devices' ignored
[    4.401308] zram: Created 32 device(s) ...
```

This problem was reported downstream at Arch: https://bugs.archlinux.org/task/41354
