### PR TITLE
the default value for zram[force] is "true" and is not "force"

### DIFF
--- a/systemd-swap.sh
+++ b/systemd-swap.sh
@@ -16,7 +16,7 @@ manage_zram(){
           [ -f /dev/zram0 ] || modprobe zram num_devices=32
           zram[alg]=${zram[alg]:-lzo}
           zram[streams]=${zram[streams]:-${sys[cpu_count]}}
-          zram[force]=${zram[force]:-force}
+          zram[force]=${zram[force]:-true}
           # Wrapper, for handling zram initialization problems
           while :; do
               # zramctl is a external program -> return name of first free device


### PR DESCRIPTION
Fixes an issue with zram initialization and a error in log if zram create attempt fails:
```
Sep 02 11:57:24 archi systemd-swap.sh[487]: zramctl: /dev/zram0: failed to reset: Device or resource busy
Sep 02 11:57:24 archi systemd-swap.sh[487]: /usr/lib/systemd/scripts/systemd-swap.sh: line 27: force: command not found
Sep 02 11:57:24 archi systemd-swap.sh[487]: mkswap: error: Nowhere to set up swap on?
Sep 02 11:57:24 archi systemd-swap.sh[487]: Usage:
Sep 02 11:57:24 archi systemd-swap.sh[487]: mkswap [options] device [size]
Sep 02 11:57:24 archi systemd-swap.sh[487]: Set up a Linux swap area.
Sep 02 11:57:24 archi systemd-swap.sh[487]: Options:
Sep 02 11:57:24 archi systemd-swap.sh[487]: -c, --check               check bad blocks before creating the swap area
Sep 02 11:57:24 archi systemd-swap.sh[487]: -f, --force               allow swap size area be larger than device
Sep 02 11:57:24 archi systemd-swap.sh[487]: -p, --pagesize SIZE       specify page size in bytes
Sep 02 11:57:24 archi systemd-swap.sh[487]: -L, --label LABEL         specify label
Sep 02 11:57:24 archi systemd-swap.sh[487]: -v, --swapversion NUM     specify swap-space version number
Sep 02 11:57:24 archi systemd-swap.sh[487]: -U, --uuid UUID           specify the uuid to use
Sep 02 11:57:24 archi systemd-swap.sh[487]: -V, --version             output version information and exit
Sep 02 11:57:24 archi systemd-swap.sh[487]: -h, --help                display this help and exit
```