### PR TITLE
Use 0/1 consistently in example swap.conf

### DIFF
--- a/swap.conf
+++ b/swap.conf
@@ -9,7 +9,7 @@
 # Zswap create compress cache between swap and memory for reduce IO
 # https://www.kernel.org/doc/Documentation/vm/zswap.txt
 
-zswap_enabled=Y
+zswap_enabled=1
 zswap_compressor=lz4
 zswap_max_pool_percent=25
 zswap_zpool=z3fold


### PR DESCRIPTION
All other enabled switches are using 0/1, only zswap is using "Y". This commit makes them consistent.