### PR TITLE
Can now read config files from /home, /root, and /run/user

### DIFF
--- a/systemd-swap.service
+++ b/systemd-swap.service
@@ -16,7 +16,7 @@ CPUAccounting=true
 CPUQuota=5%
 MemoryHigh=16M
 MemoryMax=64M
-ProtectHome=true
+ProtectHome=read-only
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
`ProtectHome=true` is too strict as systemd-swap can't read config files symlinked from /home, /root or /run/user.
`ProtectHome=read-only` fixes the problem.