### PR TITLE
define an option to set zram memory limit

### DIFF
--- a/swap.conf
+++ b/swap.conf
@@ -29,6 +29,7 @@ zswap_zpool=z3fold        # zbud z3fold
 zram_enabled=0
 zram_size=$(($ram_size/4))K     # This is 1/4 of ram size by default.
 zram_streams=$cpu_count
+zram_mem_limit=0                # 0 - unlimited
 zram_alg=lz4                    # lzo lz4 deflate lz4hc 842 - for Linux 4.8.4
 zram_prio=32767                 # 1 - 32767
 

--- a/systemd-swap
+++ b/systemd-swap
@@ -113,6 +113,7 @@ case "$1" in
             zram_streams=${zram_streams:-$cpu_count}
             zram_alg=${zram_alg:-"lz4"}
             zram_prio=${zram_prio:-"32767"}
+            zram_mem_limit=${zram_mem_limit:-0}
             zram_dev=""
             INFO "Zram: check availability"
             if [ ! -d /sys/module/zram ]; then
@@ -149,6 +150,9 @@ case "$1" in
                     /dev/zram*)
                         [ -b "$OUTPUT" ] || continue
                         zram_dev="$OUTPUT"
+                        zram_mem_limit_path="/sys/block/$(basename $zram_dev)/mem_limit"
+                        if [ -w "$zram_mem_limit_path" ]
+                        then echo $zram_mem_limit > "$zram_mem_limit_path"; fi
                         break
                     ;;
                 esac


### PR DESCRIPTION
Define a new variable, `zram_mem_limit`, which set the memory limit
for the zram device. The default value is zero which means no limit.