### PR TITLE
Support of multithread pagein from zram

### DIFF
--- a/swap.conf
+++ b/swap.conf
@@ -27,7 +27,7 @@ zswap_zpool=zbud          # zbud z3fold
 # https://www.kernel.org/doc/Documentation/blockdev/zram.txt
 
 zram_enabled=0
-zram_size=$(($RAM_SIZE*1))      # This is ram size by default (for deflate, or 1/4 for lz*)
+zram_size=$(($RAM_SIZE/4))      # This is ram size by default (for deflate, or 1/4 for lz*)
 zram_streams=$NCPU
 zram_alg=deflate                # lzo lz4 deflate lz4hc 842 - for Linux 4.8.4
 zram_prio=32767                 # 1 - 32767

--- a/swap.conf
+++ b/swap.conf
@@ -27,10 +27,11 @@ zswap_zpool=zbud          # zbud z3fold
 # https://www.kernel.org/doc/Documentation/blockdev/zram.txt
 
 zram_enabled=0
-zram_size=$(($RAM_SIZE/4))      # This is 1/4 of ram size by default.
+zram_size=$(($RAM_SIZE*1))      # This is ram size by default (for deflate, or 1/4 for lz*)
 zram_streams=$NCPU
-zram_alg=lz4                    # lzo lz4 deflate lz4hc 842 - for Linux 4.8.4
+zram_alg=deflate                # lzo lz4 deflate lz4hc 842 - for Linux 4.8.4
 zram_prio=32767                 # 1 - 32767
+zram_rstreams=$(($NCPU*4))
 
 ################################################################################
 # Swap File Chunked

--- a/systemd-swap
+++ b/systemd-swap
@@ -170,10 +170,14 @@ case "$1" in
                 zram_enabled=${zram_enabled:-0}
                 if YN $zram_enabled; then
                         [ -z "$zram_size" ] && zram_size=$((RAM_SIZE/4))
-                        zram_streams=${zram_streams:-$NCPU}
+                        zram_rstreams=${zram_rstreams:-1}
+                        zram_streams=$((${zram_streams:-$NCPU}/$zram_rstreams))
                         zram_alg=${zram_alg:-"lz4"}
                         zram_prio=${zram_prio:-"32767"}
                         zram_dev=""
+
+                        zram_wstreams=$(($zram_streams>0?$zram_streams:1))
+                        zram_size=$(($zram_size/$zram_rstreams))
 
                         INFO "Zram: check availability"
                         if [ ! -d /sys/module/zram ]; then
@@ -190,41 +194,55 @@ case "$1" in
                                 INFO "Zram: module already loaded"
                         fi
 
-                        for (( i = 0; i < 10; i++ )); do
-                                INFO "Zram: trying to initialize free device"
-                                # zramctl is a external program -> return name of first free device
-                                TMP=$(mktemp)
-                                zramctl -f -a $zram_alg -t $zram_streams -s $zram_size &> $TMP
-                                read -r OUTPUT < $TMP
-                                rm -f $TMP
-                                case "$OUTPUT" in
-                                        *"failed to reset: Device or resource busy"*)
-                                                sleep 1
-                                        ;;
-                                        *"zramctl: no free zram device found"*)
-                                                WARN "Zram: zramctl can't find free device"
-                                                INFO "Zram: using workaround hook for hot add"
-                                                [ ! -f /sys/class/zram-control/hot_add ] && \
-                                                        ERRO "Zram: this kernel does not support hot add zram device, please use 4.2+ kernels or see modinfo zram and make a modprobe rule"
-                                                read -r NEW_ZRAM < /sys/class/zram-control/hot_add
-                                                INFO "Zram: success: new device /dev/zram$NEW_ZRAM"
-                                        ;;
-                                        /dev/zram*)
-                                                [ -b "$OUTPUT" ] || continue
-                                                zram_dev="$OUTPUT"
-                                                break
-                                        ;;
-                                esac
-                        done
-                        if [ -b "$zram_dev" ]; then
-                            INFO "Zram: initialized: $zram_dev"
-                            mkswap "$zram_dev" &> /dev/null && \
-                            UNIT_NAME=$(gen_swap_unit What="$zram_dev" Options=discard Priority=$zram_prio Tag=zram)
-                            systemctl daemon-reload
-                            systemctl start $UNIT_NAME
-                        else
-                            WARN "Can't get free Zram device"
-                        fi
+gen_zram_device(){
+
+  INFO "Zram: trying to initialize free device"
+  for (( i = 0; i < 10; i++ )); do
+          # zramctl is a external program -> return name of first free device
+          TMP=$(mktemp)
+          zramctl -f -a $zram_alg -t $zram_wstreams -s $zram_size &> $TMP
+          read -r OUTPUT < $TMP
+          rm -f $TMP
+          case "$OUTPUT" in
+                  *"failed to reset: Device or resource busy"*)
+                          sleep 1
+                  ;;
+                  *"zramctl: no free zram device found"*)
+                          WARN "Zram: zramctl can't find free device"
+                          INFO "Zram: using workaround hook for hot add"
+                          [ ! -f /sys/class/zram-control/hot_add ] && \
+                                  ERRO "Zram: this kernel does not support hot add zram device, please use 4.2+ kernels or see modinfo zram and make a modprobe rule"
+                          read -r NEW_ZRAM < /sys/class/zram-control/hot_add
+                          INFO "Zram: success: new device /dev/zram$NEW_ZRAM"
+                  ;;
+                  /dev/zram*)
+                          [ -b "$OUTPUT" ] || continue
+                          zram_dev="$OUTPUT"
+                          break
+                  ;;
+          esac
+  done
+
+  if [ -b "$zram_dev" ]; then
+    return;
+  else
+    ERRO "Zram: failed to init device"
+  fi
+}
+
+                        for ((dev = 0; dev < zram_rstreams; dev++)); do
+                              gen_zram_device
+
+                              if [ -b "$zram_dev" ]; then
+                                    INFO "Zram: initialized: $zram_dev"
+                                    mkswap "$zram_dev" &> /dev/null && \
+                                    UNIT_NAME=$(gen_swap_unit What="$zram_dev" Options=discard Priority=$zram_prio Tag=zram)
+                                    systemctl daemon-reload
+                                    systemctl start $UNIT_NAME
+                                else
+                                    WARN "Can't get free Zram device"
+                              fi
+                        done;
                 fi
 
                 swapfc_enabled=${swapfc_enabled:-0}
@@ -424,7 +442,13 @@ case "$1" in
                                 DEV=$(GET_WHAT_FROM_SWAP_UNIT $UNIT_PATH)
                                 UNIT_NAME=$(basename $UNIT_PATH)
                                 INFO "Zram: swapoff $DEV"
-                                swapoff "$DEV"
+                                swapoff "$DEV" &
+                        fi
+                        wait
+                        if grep -q zram $UNIT_PATH; then
+                                DEV=$(GET_WHAT_FROM_SWAP_UNIT $UNIT_PATH)
+                                UNIT_NAME=$(basename $UNIT_PATH)
+                                INFO "Zram: rm device $DEV"
                                 rm -f $UNIT_PATH
                                 zramctl -r "$DEV"
                         fi

--- a/systemd-swap
+++ b/systemd-swap
@@ -110,6 +110,48 @@ gen_swap_unit(){
 }
 
 ################################################################################
+# zram device generator
+gen_zram_device(){
+        export Algo WStreams Size
+        for i in "$@"; do
+            case $i in
+                Algo=*)     Algo="${i//Algo=/}" ;;
+                WStreams=*) WStreams="${i//WStreams=/}" ;;
+                Size=*)  Size="${i//Size=/}"   ;;
+            esac
+        done
+
+
+        for (( i = 0; i < 10; i++ )); do
+                # zramctl is a external program -> return name of first free device
+                TMP=$(mktemp)
+                zramctl -f -a $Algo -t $WStreams -s $Size &> $TMP
+                read -r OUTPUT < $TMP
+                rm -f $TMP
+                case "$OUTPUT" in
+                        *"failed to reset: Device or resource busy"*)
+                                sleep 1
+                        ;;
+                        *"zramctl: no free zram device found"*)
+                                # WARN "Zram: zramctl can't find free device"
+                                # INFO "Zram: using workaround hook for hot add"
+                                [ ! -f /sys/class/zram-control/hot_add ] && \
+                                        ERRO "Zram: this kernel does not support hot add zram device, please use 4.2+ kernels or see modinfo zram and make a modprobe rule"
+                                read -r NEW_ZRAM < /sys/class/zram-control/hot_add
+                                # INFO "Zram: success: new device /dev/zram$NEW_ZRAM"
+                        ;;
+                        /dev/zram*)
+                                [ -b "$OUTPUT" ] || continue
+                                zram_dev="$OUTPUT"
+                                break
+                        ;;
+                esac
+        done
+
+        echo $zram_dev
+}
+
+################################################################################
 # INIT
 ################################################################################
 
@@ -194,44 +236,12 @@ case "$1" in
                                 INFO "Zram: module already loaded"
                         fi
 
-gen_zram_device(){
 
-  INFO "Zram: trying to initialize free device"
-  for (( i = 0; i < 10; i++ )); do
-          # zramctl is a external program -> return name of first free device
-          TMP=$(mktemp)
-          zramctl -f -a $zram_alg -t $zram_wstreams -s $zram_size &> $TMP
-          read -r OUTPUT < $TMP
-          rm -f $TMP
-          case "$OUTPUT" in
-                  *"failed to reset: Device or resource busy"*)
-                          sleep 1
-                  ;;
-                  *"zramctl: no free zram device found"*)
-                          WARN "Zram: zramctl can't find free device"
-                          INFO "Zram: using workaround hook for hot add"
-                          [ ! -f /sys/class/zram-control/hot_add ] && \
-                                  ERRO "Zram: this kernel does not support hot add zram device, please use 4.2+ kernels or see modinfo zram and make a modprobe rule"
-                          read -r NEW_ZRAM < /sys/class/zram-control/hot_add
-                          INFO "Zram: success: new device /dev/zram$NEW_ZRAM"
-                  ;;
-                  /dev/zram*)
-                          [ -b "$OUTPUT" ] || continue
-                          zram_dev="$OUTPUT"
-                          break
-                  ;;
-          esac
-  done
-
-  if [ -b "$zram_dev" ]; then
-    return;
-  else
-    ERRO "Zram: failed to init device"
-  fi
-}
 
                         for ((dev = 0; dev < zram_rstreams; dev++)); do
-                              gen_zram_device
+
+                              INFO "Zram: trying to initialize free device"
+                              zram_dev=$(gen_zram_device Algo="$zram_alg" WStreams="$zram_wstreams" Size="$zram_size")
 
                               if [ -b "$zram_dev" ]; then
                                     INFO "Zram: initialized: $zram_dev"
@@ -444,7 +454,11 @@ gen_zram_device(){
                                 INFO "Zram: swapoff $DEV"
                                 swapoff "$DEV" &
                         fi
-                        wait
+                done
+
+                wait
+
+                FIND_SWAP_UNITS | while read -r UNIT_PATH; do
                         if grep -q zram $UNIT_PATH; then
                                 DEV=$(GET_WHAT_FROM_SWAP_UNIT $UNIT_PATH)
                                 UNIT_NAME=$(basename $UNIT_PATH)


### PR DESCRIPTION
There was a lot of discussions about multithreaded pagein from a single device in Linux kernel. But none of them lead to actual fixes. They all agreed that this is a complicated task with no real need. So for increased speed of pagein (which has the most effect on the responsiveness of my desktop under huge overcommit).

So i made a simple extension of the script allowing it to setup multiple zram devices. It was tested and confirmed great results at my 2 core i3 mobile processor with deflate overcommit 1.9.
On top of the presets i would recommend:
`ionice -c 2` (or real-time) for kswapd, `vm.vfs_cache_pressure 150` (over time file cache becomes bottleneck), `vm.swapiness 100` (more pageout per kernel call).

`vm.oom_dump_tasks 0` - otherwise if more than ~60% of your physical ram consumed as zram device (~2.7 overcommit for deflate), you might get kernel panic out of the blue. 
Play with `vm.page_cluster` on your system, I do not have preferred value yet.