### PR TITLE
Use normal swap files on btrfs when it's supported

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -267,7 +267,9 @@ case "$1" in
 
       YN "${swapfc_force_use_loop}" && FSTYPE=btrfs
 
-      [ "${FSTYPE}" != btrfs ] && swapfc_force_preallocated=1
+      #TODO: Check if running on an older kernel where btrfs didn't yet support swap files
+      #[ "${FSTYPE}" != btrfs ] && swapfc_force_preallocated=1
+      swapfc_force_preallocated=1
 
       check_ENOSPC(){
         path="$1"
@@ -311,11 +313,12 @@ case "$1" in
 
         RET="${file}"
         case "${FSTYPE}" in
-          ext2|ext3|ext4)
+          ext2|ext3|ext4|btrfs)
           ;;
-          btrfs)
-            RET=$(losetup_w "${file}")
-          ;;
+	  # TODO: enable on kernel < 5
+          #btrfs)
+          #  RET=$(losetup_w "${file}")
+          #;;
           *)
             # -z rewrite file second time
             # By default shred gen random

--- a/systemd-swap
+++ b/systemd-swap
@@ -265,11 +265,14 @@ case "$1" in
       BLOCK_SIZE=$(stat -f -c %s "${swapfc_path}")
       FSTYPE=$(get_fs_type "${swapfc_path}")
 
-      YN "${swapfc_force_use_loop}" && FSTYPE=btrfs
+      # don't enable regular swap files on btrfs system with kernel version lower than 5,
+      #		force swap through loop files instead
+      if [ "$FSTYPE" = "btrfs" ] && [ $(uname -r | cut -d. -f1) -lt 5 ]; then
+            FSTYPE="btrfs_old"
+      fi
 
-      #TODO: Check if running on an older kernel where btrfs didn't yet support swap files
-      #[ "${FSTYPE}" != btrfs ] && swapfc_force_preallocated=1
-      swapfc_force_preallocated=1
+      YN "${swapfc_force_use_loop}" && FSTYPE=btrfs_old
+      [ "${FSTYPE}" != "btrfs_old" ] && swapfc_force_preallocated=1
 
       check_ENOSPC(){
         path="$1"
@@ -315,10 +318,9 @@ case "$1" in
         case "${FSTYPE}" in
           ext2|ext3|ext4|btrfs)
           ;;
-	  # TODO: enable on kernel < 5
-          #btrfs)
-          #  RET=$(losetup_w "${file}")
-          #;;
+          btrfs_old)
+            RET=$(losetup_w "${file}")
+          ;;
           *)
             # -z rewrite file second time
             # By default shred gen random

--- a/systemd-swap
+++ b/systemd-swap
@@ -265,10 +265,14 @@ case "$1" in
       BLOCK_SIZE=$(stat -f -c %s "${swapfc_path}")
       FSTYPE=$(get_fs_type "${swapfc_path}")
 
-      # don't enable regular swap files on btrfs system with kernel version lower than 5,
-      #		force swap through loop files instead
-      if [ "$FSTYPE" = "btrfs" ] && [ $(uname -r | cut -d. -f1) -lt 5 ]; then
-            FSTYPE="btrfs_old"
+      if [ "$FSTYPE" = "btrfs" ]; then
+            # if btrfs supports regular swap files(kernel version 5+), force disable COW to avoid data corruption
+            # if it doesn't, use the old swap through loop workaround
+            if [ $(uname -r | cut -d. -f1) -ge 5 ]; then
+                  swapfc_nocow=true
+            else
+                  FSTYPE="btrfs_old"
+            fi
       fi
 
       YN "${swapfc_force_use_loop}" && FSTYPE=btrfs_old


### PR DESCRIPTION
I'm using btrfs on my root drive. Since Linux 5.x btrfs started supporting normal swap files yet the script still forced using them through loop devices. In this PR I added a small check to enable swap files on btrfs when supported