### PR TITLE
More accurate zswap compressor hint

### DIFF
--- a/swap.conf
+++ b/swap.conf
@@ -15,7 +15,7 @@
 # https://www.kernel.org/doc/Documentation/vm/zswap.txt
 
 zswap_enabled=1
-zswap_compressor=lz4      # lzo lz4
+zswap_compressor=lz4      # see compression algorithms in /proc/crypto
 zswap_max_pool_percent=25 # 1-99
 zswap_zpool=zbud          # zbud z3fold
 


### PR DESCRIPTION
This is based on my understanding of what `zswap_compressor` allows, having seen some people happily go with `zswap_compressor=zstd` online.