### PR TITLE
Fix several grammar issues in README and .conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # systemd-swap
 
-Script for manage swap on:
+Script to manage swap on:
 
 - [zswap](https://www.kernel.org/doc/Documentation/vm/zswap.txt) - Enable/Configure
 - [zram](https://www.kernel.org/doc/Documentation/blockdev/zram.txt) - Autoconfigurating for swap
-- files - (sparse files for saving space, support btrfs)
+- files - (sparse files for saving space, supports btrfs)
 - block devices - auto find and do swapon
 
 :information_source: It is configurable in `/etc/systemd/swap.conf`.
 
 Additional terms:
 
-- **SwapFC** (File Chunked) - provide a dynamic swap file allocation/deallocation
+- **SwapFC** (File Chunked) - provides a dynamic swap file allocation/deallocation
 
-## Files placed
+## File location
 
 ```text
 /etc/systemd/swap.conf
@@ -21,7 +21,7 @@ Additional terms:
 /usr/bin/systemd-swap
 ```
 
-## Please not forget to enable by
+## Please don't forget to enable with
 
 ```shell
 sudo systemctl enable systemd-swap
@@ -55,21 +55,21 @@ sudo systemctl enable systemd-swap
 
 ## About configuration
 
-**Q**: WTF?! Why you merge swapFC and swapFU?\
-**A**: That simplify testing of swapFC code and make code more generic
+**Q**: WTF?! Why do you merge swapFC and swapFU?\
+**A**: It simplifies testing of swapFC code and makes the code more generic.
 
-**Q**: How can i migrate config swapFU from 3.X to 4.X?\
-**A**: Most of switches are same, to get configuration like swapFU from swapFC, set `swapfc_max_count` to `1` and `swapfc_chunk_size` to size of swapFU.
+**Q**: How can I migrate swapFU config from 3.X to 4.X?\
+**A**: Most of the switches are the same, to get configuration like swapFU from swapFC, set `swapfc_max_count` to `1` and `swapfc_chunk_size` to size of swapFU.
 
 **Q**: Do we need to activate both zram and zswap?\
 **A**: Nope, it's useless, as zram is a compressed RAM DISK, but zswap is a compressed _"writeback"_ CACHE on swap file/disk.
 
-**Q**: Do i need use `swapfc_force_use_loop` on swapFC?\
-**A**: Nope, as you wish really, native swapfile must work faster and it's more safe in OOM condition in comparison to loop backed scenario.
+**Q**: Do I need to use `swapfc_force_use_loop` on swapFC?\
+**A**: Nope, as you wish really, native swapfile should work faster and it's safer in OOM condition in comparison to loop backed scenario.
 
 **Q**: When would we want a certain configuration?\
-**A**: In most cases (Notebook, Desktop, Server) it's enough to enable zswap + swapfc (On server tuning of swapfc can be needed).
-In case where SSD used, and you care about flash wear, use only ZRam.
+**A**: In most cases (Notebook, Desktop, Server) it's enough to enable zswap + swapfc (on server tuning of swapfc can be needed).
+If you use SSD and care about flash memory wear, use only ZRam.
 
 **Q**: Where is the swap file located?\
 **A**: Read carefully swap.conf
@@ -80,7 +80,7 @@ In case where SSD used, and you care about flash wear, use only ZRam.
 ## Note
 
 - :information_source: Zram dependence: util-linux >= 2.26
-- :information_source: If you use zram not for only swap, use kernel 4.2+ or please add rule for modprobe like:
+- :information_source: If you use zram not for swap only, use kernel 4.2+ or please add rule for modprobe like:
 
   ```ini
   options zram max_devices=32
@@ -88,14 +88,14 @@ In case where SSD used, and you care about flash wear, use only ZRam.
 
 ## Switch On Systemd Swap
 
-- For check your configuration:
+- Check your configuration:
 
   ```shell
   cat /proc/sys/vm/swappiness
   cat /proc/sys/vm/vfs_cache_pressure
   ```
 
-- Recomended configuration for Desktop:
+- Recommended configuration for Desktop:
 
   ```shell
   echo vm.swappiness=5 | sudo tee -a /etc/sysctl.d/99-sysctl.conf
@@ -103,7 +103,7 @@ In case where SSD used, and you care about flash wear, use only ZRam.
   sudo sysctl -p /etc/sysctl.d/99-sysctl.conf
   ```
 
-- If you have install Systemd Swap check configuration:
+- Check configuration after Systemd Swap is installed:
 
   ```shell
   nano /etc/systemd/swap.conf
@@ -121,7 +121,7 @@ In case where SSD used, and you care about flash wear, use only ZRam.
   sudo swapoff -a
   ```
 
-- Need to remove swap from fstab:
+- Remove swap entry from fstab:
 
   ```shell
   nano /etc/fstab

--- a/swap.conf
+++ b/swap.conf
@@ -3,7 +3,7 @@
 ################################################################################
 
 ################################################################################
-# You can override any settings by files in:
+# You can override any settings with files in:
 # /etc/systemd/swap.conf.d/*.conf
 ################################################################################
 
@@ -11,7 +11,7 @@
 # Zswap
 #
 # Kernel >= 3.11
-# Zswap create compress cache between swap and memory for reduce IO
+# Zswap create compress cache between swap and memory to reduce IO
 # https://www.kernel.org/doc/Documentation/vm/zswap.txt
 
 zswap_enabled=1
@@ -39,7 +39,7 @@ zram_prio=32767                  # 1 - 32767
 # ex. Min swap size 512M, Max 8*512M
 swapfc_enabled=0
 swapfc_force_use_loop=0     # Force usage of swapfile + loop
-swapfc_frequency=1s         # How often check free swap space
+swapfc_frequency=1s         # How often to check free swap space
 swapfc_chunk_size=512M      # Allocate size of swap chunk
 swapfc_max_count=8          # note: 32 is a kernel maximum
 swapfc_free_swap_perc=15    # Add new chunk if free < 15%


### PR DESCRIPTION
Consistency of the README can be further improved, for example you can find *zram*, *Zram*, *ZRam* in it there.

Note: Russian is my native so I undertood the original language constructs that were translated into English,