### PR TITLE
Fix failed swap units

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -379,7 +379,7 @@ case "$1" in
                 DEV=$(GET_WHAT_FROM_SWAP_UNIT "${UNIT_PATH}")
                 UNIT_NAME=$(basename "${UNIT_PATH}")
                 systemctl stop "${UNIT_NAME}" || swapoff "${DEV}"
-                rm -f "${UNIT_NAME}"
+                rm -vf "${UNIT_PATH}"
                 [ -f "${DEV}" ] && rm -f "${DEV}"
               fi
             done
@@ -398,7 +398,7 @@ case "$1" in
           DEV=$(GET_WHAT_FROM_SWAP_UNIT "${UNIT_PATH}")
           UNIT_NAME=$(basename "${UNIT_PATH}")
           swapoff "${DEV}"
-          rm -f "${UNIT_NAME}"
+          rm -vf "${UNIT_PATH}"
         fi
       done
 
@@ -425,7 +425,7 @@ case "$1" in
         DEV=$(GET_WHAT_FROM_SWAP_UNIT "${UNIT_PATH}")
         UNIT_NAME=$(basename "${UNIT_PATH}")
         swapoff "${DEV}"
-        rm -vf "${UNIT_NAME}"
+        rm -vf "${UNIT_PATH}"
       fi
     done
 
@@ -439,7 +439,7 @@ case "$1" in
         DEV=$(GET_WHAT_FROM_SWAP_UNIT "${UNIT_PATH}")
         UNIT_NAME=$(basename "${UNIT_PATH}")
         swapoff "${DEV}"
-        rm -vf "${UNIT_NAME}"
+        rm -vf "${UNIT_PATH}"
         [ -f "${DEV}" ] && rm -f "${DEV}"
       fi
     done


### PR DESCRIPTION
There are some failed swap units but the corresponding swap files are deleted. It looks like the unit files are not deleted as expected as wrong variable name was used.

    % systemctl --failed
      UNIT                                  LOAD   ACTIVE SUB    DESCRIPTION
    ● var-lib-systemd\x2dswap-swapfc-7.swap loaded failed failed Swap File  
    ● var-lib-systemd\x2dswap-swapfc-8.swap loaded failed failed Swap File