### PR TITLE
[Performance] Only search needed directories.

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -40,7 +40,7 @@ read_l(){
 
 get_fs_type(){ df "$1" --output=fstype | tail -n 1; }
 AMI_ROOT(){ [ "${UID}" == "0" ] || ERRO "Script must be run as root!"; }
-FIND_SWAP_UNITS(){ find /run/systemd/ -type f -name "*.swap"; }
+FIND_SWAP_UNITS(){ find /run/systemd/system/ /run/systemd/generator/ -type f -name "*.swap"; }
 GET_WHAT_FROM_SWAP_UNIT(){ grep What "$1" | cut -d'=' -f2; }
 help(){
   echo "$0 start|stop|status"


### PR DESCRIPTION
After analyzing the output of `sudo ls -lR /run/systemd` I concluded that only `/run/systemd/system/` and `/run/systemd/generator/` contains filesystem units.
I modified the find command according to this blogpost: https://alvinalexander.com/blog/post/linux-unix/find-how-search-multiple-folders-directories-unix/