### PR TITLE
Fix math typo

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -379,7 +379,7 @@ case "$1" in
               losetup -d "${swapfile}"
             fi
           fi
-          (( allocated <= 2 )) && continue
+          (( allocated >= 2 )) && continue
           if (( curr_free_swap_perc > free_threshold_down )); then
             INFO "swapFC: free swap: ${curr_free_swap_perc} > ${free_threshold_down} - freeup chunk: ${allocated}"
             FIND_SWAP_UNITS | while read -r UNIT_PATH; do


### PR DESCRIPTION
Currently we only check if we want to remove a swapfile when the current amount of swapfiles are **less** or equal to 2.
This of course means that we do **not** check to remove a swapfile when we have 3 or more **and** we also waste cpu cycles checking for the removal of a swapfile whilst we only have one.