### PR TITLE
Only try to apply chattr if we're on btrfs

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -303,7 +303,7 @@ case "$1" in
         touch "${file}"
         chmod 0600 "${file}"
 
-        YN "${swapfc_nocow}" && chattr +C "${file}"
+        [ "$FSTYPE" = "btrfs" ] && YN "${swapfc_nocow}" && chattr +C "${file}"
 
         if YN ${swapfc_force_preallocated}; then
           # ext2/3 not support fallocate


### PR DESCRIPTION
Fixes clogging up log on non BTRFS filesystems (for example ext4) with `chattr: Operation not supported while setting flags on /var/lib/systemd-swap/swapfc//1`.
This could be expanded on (`FSTYPE = "btrfs"|"otherfilesystem"`) but I could not find a list of filesystems that:
a) support copy on write
b) allow for disabling copy on write with `chattr +C`