### PR TITLE
Only use `dd` for f2fs

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -311,7 +311,7 @@ case "$1" in
         chmod 0600 "${file}"
 
         [ "$FSTYPE" = "btrfs" ] && YN "${swapfc_nocow}" && chattr +C "${file}"
-        if [[ $FSTYPE = ext4 || $FSTYPE = xfs ]]; then
+        if [[ $FSTYPE = ext4 || $FSTYPE = xfs || $FSTYPE = f2fs ]]; then
           dd if=/dev/zero of="$file" bs=1M count=$(( $chunk_size / 1048576))
         else
           if YN ${swapfc_force_preallocated}; then


### PR DESCRIPTION
Make sure to use `dd` for allocating space on f2fs.
See  #114.