### PR TITLE
Do not use grep for acquiring memory stats

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -38,6 +38,28 @@ read_l(){
   echo "${DATA}" | base64 -d
 }
 
+get_mem_stat_multi() {
+  # expects name of output array as $1, followed by n wanted keys
+  local -ar fields=("${@:2}")
+  local -n outref="$1"
+  local -i matches=0
+  while read -r line; do
+    for field in "${fields[@]}"; do
+      if [[ $line =~ ^$field:[[:space:]]+([[:digit:]]+)[[:space:]]+kB$ ]]; then
+          outref+=( $(( BASH_REMATCH[1] * 1024 )) )
+          ((++matches))
+      fi
+    done
+    ((matches == ${#fields[@]})) && break;
+  done < /proc/meminfo
+}
+
+get_mem_stat() {
+  local -a value
+  get_mem_stat_multi value "$1"
+  printf "%s" "${value[0]}"
+}
+
 get_fs_type(){ df "$1" --output=fstype | tail -n 1; }
 AMI_ROOT(){ [ "${UID}" == "0" ] || ERRO "Script must be run as root!"; }
 FIND_SWAP_UNITS(){ find /run/systemd/system/ /run/systemd/generator/ -type f -name "*.swap"; }
@@ -59,7 +81,7 @@ snore()
 # Global vars
 readonly RUN_SYSD="/run/systemd"
 readonly NCPU=$(nproc)
-readonly RAM_SIZE=$(( $(grep -oP 'MemTotal:\s*\K[0-9]*' /proc/meminfo) * 1024 ))
+readonly RAM_SIZE=$(get_mem_stat MemTotal)
 readonly PAGE_SIZE=$(getconf PAGESIZE)
 readonly ETC_SYSD="/etc/systemd"
 readonly CONFIG="${ETC_SYSD}/swap.conf"
@@ -255,20 +277,19 @@ case "$1" in
       swapfc_directio=${swapfc_directio:-"1"}
       swapfc_force_preallocated=${swapfc_force_preallocated:-"0"}
       swapfc_free_swap_perc=${swapfc_free_swap_perc:-"15"}
+
       get_free_swap_perc(){
-        # +1 prevent devide by zero
-        total="$(grep -oP 'SwapTotal:\s*\K[0-9]*' /proc/meminfo)"
-        free="$(grep -oP 'SwapFree:\s*\K[0-9]*' /proc/meminfo)"
-        total=$(( total * 1024 ))
-        free=$(( free * 1024 ))
-        echo $(( (free * 100) / (total + 1) ));
+        local -a swap_stats
+        get_mem_stat_multi swap_stats SwapTotal SwapFree
+        SWAP_USED=$(( swap_stats[0] - swap_stats[1] ))
+        # minimum for total is 1 to prevent divide by zero
+        echo $(( (swap_stats[1] * 100) / (swap_stats[0] + 1) ));
       }
+      
       get_free_ram_perc(){
-        total="$(grep -oP 'MemTotal:\s*\K[0-9]*' /proc/meminfo)"
-        free="$(grep -oP 'MemFree:\s*\K[0-9]*' /proc/meminfo)"
-        total=$(( total * 1024 ))
-        free=$(( free * 1024 ))
-        echo $(( (free * 100) / total ));
+        local -a ram_stats
+        get_mem_stat_multi ram_stats MemTotal MemFree
+        echo $(( (ram_stats[1] * 100) / ram_stats[0] ));
       }
 
       to_bytes(){ numfmt --to=none --from=iec "$1"; }
@@ -512,9 +533,10 @@ case "$1" in
     rm -vf "${LOCK_STARTED}"
   ;;
   status)
-    SWAP_TOTAL=$(grep -oP 'SwapTotal:\s*\K[0-9]*' /proc/meminfo)
-    SWAP_FREE=$(grep -oP 'SwapFree:\s*\K[0-9]*' /proc/meminfo)
-    SWAP_USED=$(( (SWAP_TOTAL - SWAP_FREE) * 1024 ))
+    declare -a swap_stats
+    get_mem_stat_multi swap_stats SwapTotal SwapFree
+    SWAP_USED=$(( swap_stats[0] - swap_stats[1] ))
+    unset swap_stats
 
     if [ -d /sys/module/zswap ]; then
       echo Zswap:


### PR DESCRIPTION
This prevents multiple, periodic calls to fork() and execve() in the space detection loop.

A short test with stress-ng resulted in no noticeable behaviour changes compared to using `grep`.
  
```
[ 2527.463813] systemd-swap[6839]: INFO: Load: /etc/systemd/swap.conf
[ 2527.464706] systemd-swap[6839]: INFO: Zswap: backup current configuration: start
[ 2527.500880] systemd-swap[6839]: INFO: Zswap: backup current configuration: complete
[ 2527.500880] systemd-swap[6839]: INFO: Zswap: set new parameters: start
[ 2527.501110] systemd-swap[6839]: INFO: Zswap: Enable: 1, Comp: zstd,  Max pool %: 25, Zpool: z3fold
[ 2527.503723] systemd-swap[6839]: INFO: Zswap: set new parameters: complete
[ 2685.964052] systemd-swap[6893]: INFO: swapFC: free ram: 3 < 15 - allocate chunk: 1
[ 2686.687438] systemd-swap[7397]: 256+0 records in
[ 2686.687438] systemd-swap[7397]: 256+0 records out
[ 2686.687438] systemd-swap[7397]: 268435456 bytes (268 MB, 256 MiB) copied, 0.698947 s, 384 MB/s
[ 2686.715185] systemd-swap[7404]: Setting up swapspace version 1, size = 256 MiB (268431360 bytes), LABEL=SWAP_ext4_1, UUID=33df45c9-42c0-446e-bb9d-fe7bf2b4ab63
[ 2689.260785] systemd-swap[6893]: INFO: swapFC: free swap: 7 < 15 - allocate chunk: 2
[ 2691.006919] systemd-swap[7441]: 256+0 records in
[ 2691.006919] systemd-swap[7441]: 256+0 records out
[ 2691.006919] systemd-swap[7441]: 268435456 bytes (268 MB, 256 MiB) copied, 1.64816 s, 163 MB/s
[ 2691.032042] systemd-swap[7448]: Setting up swapspace version 1, size = 256 MiB (268431360 bytes), LABEL=SWAP_ext4_2, UUID=8350a783-a093-4271-9c10-eae387f7ae3e
[ 2694.563788] systemd-swap[6893]: INFO: swapFC: free swap: 1 < 15 - allocate chunk: 3
[ 2695.414682] systemd-swap[7479]: 256+0 records in
[ 2695.414682] systemd-swap[7479]: 256+0 records out
[ 2695.416454] systemd-swap[7479]: 268435456 bytes (268 MB, 256 MiB) copied, 0.836923 s, 321 MB/s
[ 2695.443459] systemd-swap[7484]: Setting up swapspace version 1, size = 256 MiB (268431360 bytes), LABEL=SWAP_ext4_3, UUID=31c6bfe1-aa48-4232-9b50-79ecfcf222d9
[ 2697.181562] systemd-swap[6893]: INFO: swapFC: free swap: 59 > 55 - freeup chunk: 3
[ 2701.314634] systemd-swap[7525]: removed '/run/systemd/system/var-lib-systemd\x2dswap-swapfc-3.swap'
[ 2704.765995] systemd-swap[6893]: INFO: swapFC: free swap: 0 < 15 - allocate chunk: 3
[ 2706.718486] systemd-swap[7547]: 256+0 records in
[ 2706.718486] systemd-swap[7547]: 256+0 records out
[ 2706.718486] systemd-swap[7547]: 268435456 bytes (268 MB, 256 MiB) copied, 0.63301 s, 424 MB/s
[ 2706.740984] systemd-swap[7552]: Setting up swapspace version 1, size = 256 MiB (268431360 bytes), LABEL=SWAP_ext4_3, UUID=b8960481-59d9-4e5b-883d-db207f296ef7
[ 2711.432045] systemd-swap[6893]: INFO: swapFC: free swap: 4 < 15 - allocate chunk: 4
[ 2713.586102] systemd-swap[7585]: 256+0 records in
[ 2713.586102] systemd-swap[7585]: 256+0 records out
[ 2713.589069] systemd-swap[7585]: 268435456 bytes (268 MB, 256 MiB) copied, 1.96741 s, 136 MB/s
[ 2713.617130] systemd-swap[7591]: Setting up swapspace version 1, size = 256 MiB (268431360 bytes), LABEL=SWAP_ext4_4, UUID=b92eec96-15ca-42f4-b4d1-2491d5ba6585
[ 2715.486914] systemd-swap[6893]: INFO: swapFC: free swap: 64 > 55 - freeup chunk: 4
[ 2716.550767] systemd-swap[7632]: removed '/run/systemd/system/var-lib-systemd\x2dswap-swapfc-4.swap'
[ 2717.612564] systemd-swap[6893]: INFO: swapFC: free swap: 69 > 55 - freeup chunk: 3
[ 2717.693443] systemd-swap[7649]: removed '/run/systemd/system/var-lib-systemd\x2dswap-swapfc-3.swap'
```
