### PR TITLE
Follow systemd configuration loading scheme

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -182,7 +182,7 @@ case "$1" in
       # regardless of which of the directories they reside in.
       local -A A_CONF
       for CONF in {"${VEN_SYSD}","${RUN_SYSD}","${ETC_SYSD}"}/swap.conf.d/*.conf; do
-        if [[ ! -r ${CONF} ]]; then
+        if [[ ! -r ${CONF} || -d ${CONF} ]]; then
           [[ -f ${CONF} ]] && WARN "Permission denied reading: ${CONF}"
           continue
         fi


### PR DESCRIPTION
In preparation for https://github.com/Nefelim4ag/systemd-swap/issues/123.

Please test before considering merging.

With modified paths for testing I get these (to my understanding correct) results:

```bash
RUN_SYSD="/tmp/swap/systemd/run"
ETC_SYSD="/tmp/swap/systemd/etc"
VEN_SYSD="/tmp/swap/systemd/usr"
```
```
➜ tree /tmp/swap/systemd
/tmp/swap/systemd
├── etc
│   └── swap.conf.d
│       ├── 01( )-all.conf
│       ├── 01-all.conf
│       ├── 01-etc.conf
│       ├── 01-run_etc.conf
│       ├── all.conf
│       ├── etc.conf
│       ├── etc_lib.conf
│       └── run_etc.conf
├── lib
│   └── swap.conf.d
│       ├── 01( )-all.conf
│       ├── 01-all.conf
│       ├── 01-lib.conf
│       ├── all.conf
│       └── etc_lib.conf
└── run
    ├── swap.conf.d
    │   ├── 01( )-all.conf
    │   ├── 01-all.conf
    │   ├── 01-run.conf
    │   ├── 01-run_etc.conf
    │   ├── all.conf
    │   └── run_etc.conf
```
Results in:
```
➜ ./systemd-swap start    
DEBUG: found /tmp/swap/systemd/lib/swap.conf.d/01( )-all.conf
DEBUG: found /tmp/swap/systemd/lib/swap.conf.d/01-all.conf
DEBUG: found /tmp/swap/systemd/lib/swap.conf.d/01-lib.conf
DEBUG: found /tmp/swap/systemd/lib/swap.conf.d/all.conf
DEBUG: found /tmp/swap/systemd/lib/swap.conf.d/etc_lib.conf 
DEBUG: found /tmp/swap/systemd/run/swap.conf.d/01( )-all.conf
DEBUG: found /tmp/swap/systemd/run/swap.conf.d/01-all.conf
DEBUG: found /tmp/swap/systemd/run/swap.conf.d/01-run.conf
DEBUG: found /tmp/swap/systemd/run/swap.conf.d/01-run_etc.conf
DEBUG: found /tmp/swap/systemd/run/swap.conf.d/all.conf
DEBUG: found /tmp/swap/systemd/run/swap.conf.d/run_etc.conf 
DEBUG: found /tmp/swap/systemd/etc/swap.conf.d/01( )-all.conf
DEBUG: found /tmp/swap/systemd/etc/swap.conf.d/01-all.conf
DEBUG: found /tmp/swap/systemd/etc/swap.conf.d/01-etc.conf
DEBUG: found /tmp/swap/systemd/etc/swap.conf.d/01-run_etc.conf
DEBUG: found /tmp/swap/systemd/etc/swap.conf.d/all.conf
DEBUG: found /tmp/swap/systemd/etc/swap.conf.d/etc.conf
DEBUG: found /tmp/swap/systemd/etc/swap.conf.d/etc_lib.conf 
DEBUG: found /tmp/swap/systemd/etc/swap.conf.d/run_etc.conf 
DEBUG: Selected configuration artifacts: /tmp/swap/systemd/etc/swap.conf.d/etc_lib.conf /tmp/swap/systemd/etc/swap.conf.d/01( )-all.conf /tmp/swap/systemd/run/swap.conf.d/01-run.conf /tmp/swap/systemd/etc/swap.conf.d/run_etc.conf /tmp/swa
p/systemd/etc/swap.conf.d/01-run_etc.conf /tmp/swap/systemd/etc/swap.conf.d/01-all.conf /tmp/swap/systemd/etc/swap.conf.d/all.conf /tmp/swap/systemd/lib/swap.conf.d/01-lib.conf /tmp/swap/systemd/etc/swap.conf.d/01-etc.conf /tmp/swap/syste
md/etc/swap.conf.d/etc.conf
DEBUG: 01( )-all.conf 01-all.conf 01-etc.conf 01-lib.conf 01-run.conf 01-run_etc.conf all.conf etc.conf etc_lib.conf run_etc.conf
INFO: Load: /tmp/swap/systemd/etc/swap.conf.d/01( )-all.conf
INFO: Load: /tmp/swap/systemd/etc/swap.conf.d/01-all.conf
INFO: Load: /tmp/swap/systemd/etc/swap.conf.d/01-etc.conf  
INFO: Load: /tmp/swap/systemd/lib/swap.conf.d/01-lib.conf
INFO: Load: /tmp/swap/systemd/run/swap.conf.d/01-run.conf
INFO: Load: /tmp/swap/systemd/etc/swap.conf.d/01-run_etc.conf               
INFO: Load: /tmp/swap/systemd/etc/swap.conf.d/all.conf                                                                 
INFO: Load: /tmp/swap/systemd/etc/swap.conf.d/etc.conf
INFO: Load: /tmp/swap/systemd/etc/swap.conf.d/etc_lib.conf
INFO: Load: /tmp/swap/systemd/etc/swap.conf.d/run_etc.conf
```

A short real world test went as expected.
