### PR TITLE
Load default configuration from /usr/share/systemd-swap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ default:  help
 LIB_T  := $(PREFIX)/var/lib/systemd-swap
 BIN_T  := $(PREFIX)/usr/bin/systemd-swap
 SVC_T  := $(PREFIX)/lib/systemd/system/systemd-swap.service
-CNF_T  := $(PREFIX)/usr/share/systemd-swap/swap.conf
+DFL_T  := $(PREFIX)/usr/share/systemd-swap/swap-default.conf
+CNF_T  := $(PREFIX)/etc/systemd/swap.conf
 
 
 $(LIB_T):
@@ -21,10 +22,13 @@ $(BIN_T): systemd-swap
 $(SVC_T): systemd-swap.service
 	install -Dm644 $< $@
 
-$(CNF_T): swap.conf
+$(DFL_T): swap-default.conf
 	install -bDm644 $< $@
 
-files: $(BIN_T) $(SVC_T) $(CNF_T)
+$(CNF_T): swap.conf
+	install -bDm644 -S .old $< $@
+
+files: $(BIN_T) $(SVC_T) $(DFL_T)
 
 
 install: ## Install systemd-swap
@@ -35,6 +39,7 @@ uninstall:
 	test ! -f /run/systemd/swap/swap.conf
 	@rm -v $(BIN_T)
 	@rm -v $(SVC_T)
+	@rm -v $(DFL_T)
 	@rm -v $(CNF_T)
 	rm -r $(PREFIX)/var/lib/systemd-swap
 	rmdir $(PREFIX)/usr/share/systemd-swap

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ETCD_T := $(PREFIX)/etc/systemd/swap.conf.d/
 
 BIN_T  := $(PREFIX)/usr/bin/systemd-swap
 SVC_T  := $(PREFIX)/lib/systemd/system/systemd-swap.service
-CNF_T  := $(PREFIX)/etc/systemd/swap.conf
+CNF_T  := $(PREFIX)/usr/share/systemd-swap/swap.conf
 
 
 $(LIB_T):
@@ -27,7 +27,7 @@ $(SVC_T): systemd-swap.service
 	install -Dm644 $< $@
 
 $(CNF_T): swap.conf
-	install -bDm644 -S .old $< $@
+	install -bDm644 $< $@
 
 files: $(BIN_T) $(SVC_T) $(CNF_T)
 
@@ -42,6 +42,7 @@ uninstall:
 	@rm -v $(SVC_T)
 	@rm -v $(CNF_T)
 	rm -r $(PREFIX)/var/lib/systemd-swap
+	rmdir $(PREFIX)/usr/share/systemd-swap
 
 deb: ## Create debian package
 deb: package.sh

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ $(DFL_T): swap-default.conf
 $(CNF_T): swap.conf
 	install -bDm644 -S .old $< $@
 
-files: $(BIN_T) $(SVC_T) $(DFL_T)
+files: $(BIN_T) $(SVC_T) $(DFL_T) $(CNF_T)
 
 
 install: ## Install systemd-swap

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ FEDORA_VERSION ?= f32
 default:  help
 
 LIB_T  := $(PREFIX)/var/lib/systemd-swap
-ETCD_T := $(PREFIX)/etc/systemd/swap.conf.d/
-
 BIN_T  := $(PREFIX)/usr/bin/systemd-swap
 SVC_T  := $(PREFIX)/lib/systemd/system/systemd-swap.service
 CNF_T  := $(PREFIX)/usr/share/systemd-swap/swap.conf
@@ -14,10 +12,7 @@ CNF_T  := $(PREFIX)/usr/share/systemd-swap/swap.conf
 $(LIB_T):
 	mkdir -p $@
 
-$(ETCD_T):
-	mkdir -p $@
-
-dirs: $(LIB_T) $(ETCD_T)
+dirs: $(LIB_T)
 
 
 $(BIN_T): systemd-swap

--- a/swap-default.conf
+++ b/swap-default.conf
@@ -37,7 +37,7 @@ zram_prio=32767                  # 1 - 32767
 # Swap File Chunked
 # Allocate swap files dynamically
 # For btrfs fallback to swapfile + loop will be used
-# ex. Min swap size 512M, Max 8*512M
+# ex. Min swap size 256M, Max 32*256M
 swapfc_enabled=0
 swapfc_force_use_loop=0     # Force usage of swapfile + loop
 swapfc_frequency=1          # How often to check free swap space

--- a/swap-default.conf
+++ b/swap-default.conf
@@ -1,0 +1,58 @@
+################################################################################
+# Defaults are optimized for general usage
+################################################################################
+
+################################################################################
+# You can override any settings with files in:
+# /etc/systemd/swap.conf.d/*.conf
+################################################################################
+
+################################################################################
+# Zswap
+#
+# Kernel >= 3.11
+# Zswap create compress cache between swap and memory to reduce IO
+# https://www.kernel.org/doc/Documentation/vm/zswap.txt
+
+zswap_enabled=1
+zswap_compressor=zstd     # lzo lz4 zstd lzo-rle lz4hc
+zswap_max_pool_percent=25 # 1-99
+zswap_zpool=z3fold        # zbud z3fold (note z3fold requires kernel 4.8+)
+
+################################################################################
+# ZRam
+#
+# Kernel >= 3.15
+# Zram compression streams count for additional information see:
+# https://www.kernel.org/doc/Documentation/blockdev/zram.txt
+
+zram_enabled=0
+zram_size=$(( RAM_SIZE / 4 ))    # This is 1/4 of ram size by default.
+zram_count=${NCPU}               # Device count
+zram_streams=${NCPU}             # Compress streams
+zram_alg=zstd                    # See $zswap_compressor
+zram_prio=32767                  # 1 - 32767
+
+################################################################################
+# Swap File Chunked
+# Allocate swap files dynamically
+# For btrfs fallback to swapfile + loop will be used
+# ex. Min swap size 512M, Max 8*512M
+swapfc_enabled=0
+swapfc_force_use_loop=0     # Force usage of swapfile + loop
+swapfc_frequency=1          # How often to check free swap space
+swapfc_chunk_size=256M      # Allocate size of swap chunk
+swapfc_max_count=32         # Note: 32 is a kernel maximum
+swapfc_free_swap_perc=15    # Add new chunk if free < 15%
+                            # Remove chunk if free > 15+40% & chunk count > 2
+swapfc_path=/var/lib/systemd-swap/swapfc/
+# Only for swapfile + loop
+swapfc_nocow=1              # Disable CoW on swapfile
+swapfc_directio=1           # Use directio for loop dev
+swapfc_force_preallocated=0 # Will preallocate created files
+
+################################################################################
+# Swap devices
+# Find and auto swapon all available swap devices
+swapd_auto_swapon=1
+swapd_prio=1024

--- a/swap.conf
+++ b/swap.conf
@@ -5,32 +5,32 @@
 # You can change settings by editing this file.
 # Defaults can be restored by simply deleting this file.
 #
-# See swap.conf(5) and /usr/share/systemd-swap/swap.conf for details.
+# See swap.conf(5) and /usr/share/systemd-swap/swap-default.conf for details.
 
 #zswap_enabled=1
-#zswap_compressor=zstd     # lzo lz4 zstd lzo-rle lz4hc
-#zswap_max_pool_percent=25 # 1-99
-#zswap_zpool=z3fold        # zbud z3fold (note z3fold requires kernel 4.8+)
+#zswap_compressor=zstd
+#zswap_max_pool_percent=25
+#zswap_zpool=z3fold
 
 #zram_enabled=0
-#zram_size=$(( RAM_SIZE / 4 ))    # This is 1/4 of ram size by default.
-#zram_count=${NCPU}               # Device count
-#zram_streams=${NCPU}             # Compress streams
-#zram_alg=zstd                    # See $zswap_compressor
-#zram_prio=32767                  # 1 - 32767
+#zram_size=$(( RAM_SIZE / 4 ))
+#zram_count=${NCPU}
+#zram_streams=${NCPU}
+#zram_alg=zstd
+#zram_prio=32767
 
 #swapfc_enabled=0
-#swapfc_force_use_loop=0     # Force usage of swapfile + loop
-#swapfc_frequency=1          # How often to check free swap space
-#swapfc_chunk_size=256M      # Allocate size of swap chunk
-#swapfc_max_count=32         # Note: 32 is a kernel maximum
-#swapfc_free_swap_perc=15    # Add new chunk if free < 15%
-                            # Remove chunk if free > 15+40% & chunk count > 2
+#swapfc_force_use_loop=0
+#swapfc_frequency=1
+#swapfc_chunk_size=256M
+#swapfc_max_count=32
+#swapfc_free_swap_perc=15
+
 #swapfc_path=/var/lib/systemd-swap/swapfc/
 
-#swapfc_nocow=1              # Disable CoW on swapfile
-#swapfc_directio=1           # Use directio for loop dev
-#swapfc_force_preallocated=0 # Will preallocate created files
+#swapfc_nocow=1
+#swapfc_directio=1
+#swapfc_force_preallocated=0
 
 #swapd_auto_swapon=1
 #swapd_prio=1024

--- a/swap.conf
+++ b/swap.conf
@@ -1,58 +1,36 @@
-################################################################################
-# Defaults are optimized for general usage
-################################################################################
-
-################################################################################
-# You can override any settings with files in:
-# /etc/systemd/swap.conf.d/*.conf
-################################################################################
-
-################################################################################
-# Zswap
+#  This file is part of systemd-swap.
 #
-# Kernel >= 3.11
-# Zswap create compress cache between swap and memory to reduce IO
-# https://www.kernel.org/doc/Documentation/vm/zswap.txt
-
-zswap_enabled=1
-zswap_compressor=zstd     # lzo lz4 zstd lzo-rle lz4hc
-zswap_max_pool_percent=25 # 1-99
-zswap_zpool=z3fold        # zbud z3fold (note z3fold requires kernel 4.8+)
-
-################################################################################
-# ZRam
+# Entries in this file show the systemd-swap defaults as
+# specified in /usr/share/systemd-swap/swap.conf
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
 #
-# Kernel >= 3.15
-# Zram compression streams count for additional information see:
-# https://www.kernel.org/doc/Documentation/blockdev/zram.txt
+# See swap.conf(5) and /usr/share/systemd-swap/swap.conf for details.
 
-zram_enabled=0
-zram_size=$(( RAM_SIZE / 4 ))    # This is 1/4 of ram size by default.
-zram_count=${NCPU}               # Device count
-zram_streams=${NCPU}             # Compress streams
-zram_alg=zstd                    # See $zswap_compressor
-zram_prio=32767                  # 1 - 32767
+#zswap_enabled=1
+#zswap_compressor=zstd     # lzo lz4 zstd lzo-rle lz4hc
+#zswap_max_pool_percent=25 # 1-99
+#zswap_zpool=z3fold        # zbud z3fold (note z3fold requires kernel 4.8+)
 
-################################################################################
-# Swap File Chunked
-# Allocate swap files dynamically
-# For btrfs fallback to swapfile + loop will be used
-# ex. Min swap size 512M, Max 8*512M
-swapfc_enabled=0
-swapfc_force_use_loop=0     # Force usage of swapfile + loop
-swapfc_frequency=1          # How often to check free swap space
-swapfc_chunk_size=256M      # Allocate size of swap chunk
-swapfc_max_count=32         # Note: 32 is a kernel maximum
-swapfc_free_swap_perc=15    # Add new chunk if free < 15%
+#zram_enabled=0
+#zram_size=$(( RAM_SIZE / 4 ))    # This is 1/4 of ram size by default.
+#zram_count=${NCPU}               # Device count
+#zram_streams=${NCPU}             # Compress streams
+#zram_alg=zstd                    # See $zswap_compressor
+#zram_prio=32767                  # 1 - 32767
+
+#swapfc_enabled=0
+#swapfc_force_use_loop=0     # Force usage of swapfile + loop
+#swapfc_frequency=1          # How often to check free swap space
+#swapfc_chunk_size=256M      # Allocate size of swap chunk
+#swapfc_max_count=32         # Note: 32 is a kernel maximum
+#swapfc_free_swap_perc=15    # Add new chunk if free < 15%
                             # Remove chunk if free > 15+40% & chunk count > 2
-swapfc_path=/var/lib/systemd-swap/swapfc/
-# Only for swapfile + loop
-swapfc_nocow=1              # Disable CoW on swapfile
-swapfc_directio=1           # Use directio for loop dev
-swapfc_force_preallocated=0 # Will preallocate created files
+#swapfc_path=/var/lib/systemd-swap/swapfc/
 
-################################################################################
-# Swap devices
-# Find and auto swapon all available swap devices
-swapd_auto_swapon=1
-swapd_prio=1024
+#swapfc_nocow=1              # Disable CoW on swapfile
+#swapfc_directio=1           # Use directio for loop dev
+#swapfc_force_preallocated=0 # Will preallocate created files
+
+#swapd_auto_swapon=1
+#swapd_prio=1024

--- a/systemd-swap
+++ b/systemd-swap
@@ -87,7 +87,7 @@ snore(){
 readonly RUN_SYSD="/run/systemd"
 readonly ETC_SYSD="/etc/systemd"
 readonly VEN_SYSD="/usr/lib/systemd"
-readonly DEF_CONFIG="/usr/share/systemd-swap/swap.conf"
+readonly DEF_CONFIG="/usr/share/systemd-swap/swap-default.conf"
 readonly ETC_CONFIG="${ETC_SYSD}/swap.conf"
 readonly NCPU=$(nproc)
 readonly RAM_SIZE=$(get_mem_stat MemTotal)

--- a/systemd-swap
+++ b/systemd-swap
@@ -168,7 +168,7 @@ case "$1" in
     touch "${LOCK_STARTED}"
 
     # load default values
-    . "${DEF_CONFIG}" || ERRO "Error loading ${ETC_CONFIG}"
+    . "${DEF_CONFIG}" || ERRO "Error loading ${DEF_CONFIG}"
 
     load_config_fragments(){
       # config precedence follows systemd scheme:

--- a/systemd-swap
+++ b/systemd-swap
@@ -172,7 +172,7 @@ case "$1" in
 
     load_config_fragments(){
       # config precedence follows systemd scheme:
-      # etc > run > lib > swap.conf
+      # etc > run > lib for all fragments > /etc/systemd/swap.conf
       if [[ -f "$ETC_CONFIG" ]]; then
         INFO "Load: ${ETC_CONFIG}"
         # shellcheck source=swap.conf

--- a/systemd-swap
+++ b/systemd-swap
@@ -87,6 +87,7 @@ snore(){
 readonly RUN_SYSD="/run/systemd"
 readonly ETC_SYSD="/etc/systemd"
 readonly VEN_SYSD="/usr/lib/systemd"
+readonly DEF_CONFIG="/usr/share/systemd-swap/swap.conf"
 readonly ETC_CONFIG="${ETC_SYSD}/swap.conf"
 readonly NCPU=$(nproc)
 readonly RAM_SIZE=$(get_mem_stat MemTotal)
@@ -166,13 +167,16 @@ case "$1" in
     [ -f "${LOCK_STARTED}" ] && ERRO "$0 already started"
     touch "${LOCK_STARTED}"
 
+    # load default values
+    . "${DEF_CONFIG}" || ERRO "Error loading ${ETC_CONFIG}"
+
     load_config_fragments(){
       # config precedence follows systemd scheme:
       # etc > run > lib > swap.conf
       if [[ -f "$ETC_CONFIG" ]]; then
         INFO "Load: ${ETC_CONFIG}"
         # shellcheck source=swap.conf
-        . "${ETC_CONFIG}" || ERRO "Error loading ${ETC_CONFIG}"
+        . "${ETC_CONFIG}" || WARN "Could not load ${ETC_CONFIG}"
       fi
       local -A a_conf
       for conf in {"${VEN_SYSD}","${RUN_SYSD}","${ETC_SYSD}"}/swap.conf.d/*.conf; do

--- a/systemd-swap
+++ b/systemd-swap
@@ -165,6 +165,7 @@ case "$1" in
   start)
     [ -f "${LOCK_STARTED}" ] && ERRO "$0 already started"
     touch "${LOCK_STARTED}"
+
     load_config_fragments(){
       # config precedence follows systemd scheme:
       # etc > run > lib > swap.conf
@@ -173,23 +174,23 @@ case "$1" in
         # shellcheck source=swap.conf
         . "${ETC_CONFIG}" || ERRO "Error loading ${ETC_CONFIG}"
       fi
-      local -A A_CONF
-      for CONF in {"${VEN_SYSD}","${RUN_SYSD}","${ETC_SYSD}"}/swap.conf.d/*.conf; do
-        if [[ ! -r ${CONF} || -d ${CONF} ]]; then
-          [[ -f ${CONF} ]] && WARN "Permission denied reading: ${CONF}"
+      local -A a_conf
+      for conf in {"${VEN_SYSD}","${RUN_SYSD}","${ETC_SYSD}"}/swap.conf.d/*.conf; do
+        if [[ ! -r ${conf} || -d ${conf} ]]; then
+          [[ -f ${conf} ]] && WARN "Permission denied reading: ${conf}"
           continue
         fi
-        A_CONF[$(basename "${CONF}")]="${CONF}"
-        DEBUG "found ${CONF}"
+        a_conf[$(basename "${conf}")]="${conf}"
+        DEBUG "found ${conf}"
       done
-      DEBUG "Selected configuration artifacts: ${A_CONF[*]}"
+      DEBUG "Selected configuration artifacts: ${a_conf[*]}"
       # sort lexicographically
-      readarray -t o_frag < <(printf '%s\n' "${!A_CONF[@]}" | sort)
-      if [[ -n ${o_frag:-} ]]; then 
+      readarray -t skeys < <(printf '%s\n' "${!a_conf[@]}" | sort)
+      if [[ -n ${skeys:-} ]]; then 
         # and finally load it
-        for fragment in "${o_frag[@]}"; do
-          INFO "Load: ${A_CONF[$fragment]}"
-          source "${A_CONF[$fragment]}" || ERRO "Error loading ${A_CONF[$fragment]}"
+        for fragment in "${skeys[@]}"; do
+          INFO "Load: ${a_conf[$fragment]}"
+          . "${a_conf[$fragment]}" || ERRO "Error loading ${a_conf[$fragment]}"
         done
       fi
     }
@@ -418,7 +419,7 @@ case "$1" in
             (( ++allocated ))
             INFO "swapFC: free ram: ${curr_free_ram_perc} < ${free_threshold_up} - allocate chunk: ${allocated}"
             swapfile=$(prepare_swapfile "${chunk_size}" "${swapfc_path}/${allocated}")
-            mkswap -L SWAP_${FSTYPE}_"${allocated}" "${swapfile}" | sed ':a;N;$!ba;s/)\n/), /g'
+            mkswap -L "SWAP_${FSTYPE}_${allocated}" "${swapfile}" | sed ':a;N;$!ba;s/)\n/), /g'
             if YN ${swapfc_force_preallocated}; then
               UNIT_NAME=$(gen_swap_unit What="${swapfile}" Tag="swapfc_${allocated}")
             else
@@ -440,7 +441,7 @@ case "$1" in
           (( ++allocated ))
           INFO "swapFC: free swap: ${curr_free_swap_perc} < ${free_threshold_up} - allocate chunk: ${allocated}"
           swapfile=$(prepare_swapfile "${chunk_size}" "${swapfc_path}/${allocated}")
-          mkswap -L SWAP_${FSTYPE}_"${allocated}" "${swapfile}" | sed ':a;N;$!ba;s/)\n/), /g'
+          mkswap -L "SWAP_${FSTYPE}_${allocated}" "${swapfile}" | sed ':a;N;$!ba;s/)\n/), /g'
           if YN ${swapfc_force_preallocated}; then
             UNIT_NAME=$(gen_swap_unit What="${swapfile}" Tag="swapfc_${allocated}")
           else
@@ -453,7 +454,7 @@ case "$1" in
         if (( curr_free_swap_perc > free_threshold_down )); then
           INFO "swapFC: free swap: ${curr_free_swap_perc} > ${free_threshold_down} - freeup chunk: ${allocated}"
           FIND_SWAP_UNITS | while read -r UNIT_PATH; do
-            if grep -q swapfc_"${allocated}" "${UNIT_PATH}"; then
+            if grep -q "swapfc_${allocated}" "${UNIT_PATH}"; then
               DEV=$(GET_WHAT_FROM_SWAP_UNIT "${UNIT_PATH}")
               UNIT_NAME=$(basename "${UNIT_PATH}")
               systemctl stop "${UNIT_NAME}" || swapoff "${DEV}"

--- a/systemd-swap
+++ b/systemd-swap
@@ -582,3 +582,5 @@ case "$1" in
     help
   ;;
 esac
+
+exit 0

--- a/systemd-swap
+++ b/systemd-swap
@@ -166,18 +166,13 @@ case "$1" in
     [ -f "${LOCK_STARTED}" ] && ERRO "$0 already started"
     touch "${LOCK_STARTED}"
     load_config_fragments(){
-      # The main configuration file is read before any of the configuration
-      # directories, and has the lowest precedence; entries in a file in any configuration
-      # directory override entries in the single configuration file.
+      # config precedence follows systemd scheme:
+      # etc > run > lib > swap.conf
       if [[ -f "$ETC_CONFIG" ]]; then
         INFO "Load: ${ETC_CONFIG}"
         # shellcheck source=swap.conf
         . "${ETC_CONFIG}" || ERRO "Error loading ${ETC_CONFIG}"
       fi
-      # Drop-in files in /etc take precedence over those in /run which
-      # in turn take precedence over those in /usr/lib.
-      # Multiple drop-in files with different names are applied in lexicographic order,
-      # regardless of which of the directories they reside in.
       local -A A_CONF
       for CONF in {"${VEN_SYSD}","${RUN_SYSD}","${ETC_SYSD}"}/swap.conf.d/*.conf; do
         if [[ ! -r ${CONF} || -d ${CONF} ]]; then

--- a/systemd-swap.service
+++ b/systemd-swap.service
@@ -25,4 +25,4 @@ RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 SystemCallFilter=@system-service @swap @module
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target

--- a/systemd-swap.service
+++ b/systemd-swap.service
@@ -25,4 +25,4 @@ RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 SystemCallFilter=@system-service @swap @module
 
 [Install]
-WantedBy=sysinit.target
+WantedBy=basic.target

--- a/systemd-swap.spec
+++ b/systemd-swap.spec
@@ -12,6 +12,7 @@ BuildArch: noarch
 
 Source1: swap.conf
 Source2: systemd-swap.service
+Source3: swap-default.conf
 
 Requires: util-linux
 

--- a/systemd-swap.spec
+++ b/systemd-swap.spec
@@ -30,8 +30,8 @@ rm -rf %{buildroot}/
 %files
 %defattr(-,root,root,-)
 %{_bindir}/*
-%{_sysconfdir}/systemd/*
-/lib/systemd/system/*
+%{_datadir}/%{name}/*
+/usr/lib/systemd/system/*
 /var/lib/*
 
 %changelog


### PR DESCRIPTION
This changes the location of the default configuration to `/usr/share/systemd-swap/swap-default.conf` which is *always* sourced, so that `/etc/systemd/swap.conf` is now optional.

Because I didn't want to hardcode every value, `/usr/share` seemed like a good location for that and since this is a complimentary utility, `/usr/share/systemd/swap-default.conf` didn't seem the right choice.

Please feel free to cherry-pick and/or squash.

Tested briefly after rebasing on 4a90328b22e47e5a2b01244d0131e8b5d00b7c11.