### PR TITLE
Fix not being able to create a btrfs snapshot if the swap file was on the same subvolume

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -345,11 +345,8 @@ case "$1" in
       if [ "$FSTYPE" = "btrfs" ]; then
         # if btrfs supports regular swap files(kernel version 5+), force disable COW to avoid data corruption
         # if it doesn't, use the old swap through loop workaround
-        (( KMAJOR >= 5 )) && swapfc_nocow=true || FSTYPE="btrfs_old"
+        (( KMAJOR >= 5 )) && swapfc_nocow=true || swapfc_force_use_loop=1
       fi
-
-      YN "${swapfc_force_use_loop}" && FSTYPE=btrfs_old
-      [ "${FSTYPE}" != "btrfs_old" ] && swapfc_force_preallocated=1
 
       check_ENOSPC(){
         path="$1"
@@ -393,7 +390,7 @@ case "$1" in
         }
 
         RET="${file}"
-        [[ "${FSTYPE}" == "btrfs_old" ]] && RET=$(losetup_w "${file}")
+        YN ${swapfc_force_use_loop} && RET=$(losetup_w "${file}")
         echo "${RET}"
       }
 

--- a/systemd-swap
+++ b/systemd-swap
@@ -67,8 +67,7 @@ get_mem_stat(){
 
 get_fs_type(){
   if [ -d "$1" ]; then path="$1";
-  elif [ -d "${1%/*/}" ]; then path="${1%/*/}";
-  elif [ -d "${1%/*}" ]; then path="${1%/*}";
+  elif [ -d $(dirname "$1") ]; then path=$(dirname "$1");
   else ERRO "swapfc_path is invalid"
   fi
   df "$path" --output=fstype | tail -n 1
@@ -336,8 +335,9 @@ case "$1" in
 
       FSTYPE=$(get_fs_type "${swapfc_path}")
       # must exists before stat()
+      mkdir -p $(dirname "$swapfc_path")
       [ "$FSTYPE" == "btrfs" ] && btrfs subvolume create "${swapfs_path}" \
-	      || mkdir -p "${swapfc_path}"
+	      || mkdir "${swapfc_path}"
 
       chunk_size=$(to_bytes "${swapfc_chunk_size}")
       BLOCK_SIZE=$(stat -f -c %s "${swapfc_path}")
@@ -437,8 +437,9 @@ case "$1" in
         systemd-notify "STATUS=Monitoring memory status..."
       }
 
+      mkdir -p $(dirname "$swapfc_path")
       [ "${FSTYPE}" == "btrfs" ] && btrfs subvolume create "${swapfc_path}" \
-	     || mkdir -p "${swapfc_path}"
+	     || mkdir "${swapfc_path}"
 
       mkdir -p \
         "${WORK_DIR}/swapfc/"

--- a/systemd-swap
+++ b/systemd-swap
@@ -336,7 +336,7 @@ case "$1" in
       FSTYPE=$(get_fs_type "${swapfc_path}")
       # must exists before stat()
       mkdir -p $(dirname "$swapfc_path")
-      [ "$FSTYPE" == "btrfs" ] && btrfs subvolume create "${swapfs_path}" \
+      [ "$FSTYPE" == "btrfs" ] && btrfs subvolume create "${swapfc_path}" \
 	      || mkdir "${swapfc_path}"
 
       chunk_size=$(to_bytes "${swapfc_chunk_size}")
@@ -437,12 +437,7 @@ case "$1" in
         systemd-notify "STATUS=Monitoring memory status..."
       }
 
-      mkdir -p $(dirname "$swapfc_path")
-      [ "${FSTYPE}" == "btrfs" ] && btrfs subvolume create "${swapfc_path}" \
-	     || mkdir "${swapfc_path}"
-
-      mkdir -p \
-        "${WORK_DIR}/swapfc/"
+      mkdir -p ${WORK_DIR}/swapfc/"
       touch "${WORK_DIR}/swapfc/.lock"
       declare -i allocated=0
       INFO "swapFC: on-demand swap activation at >$(( RAM_SIZE * (100 - swapfc_free_swap_perc) / 104857600)) MiB memory usage"

--- a/systemd-swap
+++ b/systemd-swap
@@ -65,7 +65,14 @@ get_mem_stat(){
   printf "%s" "${value[0]}"
 }
 
-get_fs_type(){ df "$1" --output=fstype | tail -n 1; }
+get_fs_type(){
+  if [ -d "$1" ]; then path="$1";
+  elif [ -d "${1%/*/}" ]; then path="${1%/*/}";
+  elif [ -d "${1%/*}" ]; then path="${1%/*}";
+  else ERRO "swapfc_path is invalid"
+  fi
+  df "$path" --output=fstype | tail -n 1
+}
 AMI_ROOT(){ [ "${UID}" == "0" ] || ERRO "Script must be run as root!"; }
 FIND_SWAP_UNITS(){ find /run/systemd/{system/,generator/} -type f -name "*.swap"; }
 GET_WHAT_FROM_SWAP_UNIT(){ grep -oP 'What=\K.*' "$1"; }
@@ -326,12 +333,14 @@ case "$1" in
       to_bytes(){ numfmt --to=none --from=iec "$1"; }
 
       systemd-notify "STATUS=Monitoring memory status..."
+
+      FSTYPE=$(get_fs_type "${swapfc_path}")
       # must exists before stat()
-      mkdir -p "${swapfc_path}"
+      [ "$FSTYPE" == "btrfs" ] && btrfs subvolume create "${swapfs_path}" \
+	      || mkdir -p "${swapfc_path}"
 
       chunk_size=$(to_bytes "${swapfc_chunk_size}")
       BLOCK_SIZE=$(stat -f -c %s "${swapfc_path}")
-      FSTYPE=$(get_fs_type "${swapfc_path}")
 
       if [ "$FSTYPE" = "btrfs" ]; then
         # if btrfs supports regular swap files(kernel version 5+), force disable COW to avoid data corruption
@@ -431,8 +440,10 @@ case "$1" in
         systemd-notify "STATUS=Monitoring memory status..."
       }
 
+      [ "${FSTYPE}" == "btrfs" ] && btrfs subvolume create "${swapfc_path}" \
+	     || mkdir -p "${swapfc_path}"
+
       mkdir -p \
-        "${swapfc_path}" \
         "${WORK_DIR}/swapfc/"
       touch "${WORK_DIR}/swapfc/.lock"
       declare -i allocated=0


### PR DESCRIPTION
Instead of creating just a directory for the swap files, create a subvolume instead to be able to create a snapshot of the fs which the swap files are located on. 

I also removed btrfs_old FSTYPE (which I shouldn't have created it really anyways, kinda an oversight on my part) and replaced it with just forcing `$swapfc_force_use_loop` on. It also fixes a bug that was introduced in a recent commit with not being able to use swap + loop on any filesystems besides btrfs(kernel < 5). I just didn't wanna create a completely separate pull request just for a single commit. 

By the way, I wanna port the project to pure POSIX sh. dash is way faster on my slow laptop than bash and I believe the project would benefit from the additional performance since it runs so frequently. Perhaps I'll also tidy up the code a bit because it's kinda messy and hard to understand right now. You don't mind, right?