### PR TITLE
Check if swapfc_path is a btrfs subvolume when df returns fstype '-'

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -70,7 +70,18 @@ get_fs_type(){
   elif [[ -d $(dirname "$1") ]]; then path=$(dirname "$1");
   else ERRO "swapfc_path is invalid"
   fi
-  df "$path" --output=fstype | tail -n 1
+
+  fstype=$(df "$path" --output=fstype | tail -n 1)
+
+  if [ "$fstype" == "-" ]; then
+    if btrfs subvolume show "$path" &>/dev/null; then
+      fstype="btrfs"
+    else
+      ERRO '$swapfc_path is located on an unknown filesystem'
+    fi
+  fi
+
+  echo "$fstype"
 }
 AMI_ROOT(){ [ "${UID}" == "0" ] || ERRO "Script must be run as root!"; }
 FIND_SWAP_UNITS(){ find /run/systemd/{system/,generator/} -type f -name "*.swap"; }

--- a/systemd-swap
+++ b/systemd-swap
@@ -73,15 +73,15 @@ get_fs_type(){
 
   fstype=$(df "$path" --output=fstype | tail -n 1)
 
-  if [ "$fstype" == "-" ]; then
+  if [[ "$fstype" == "-" ]]; then
     if btrfs subvolume show "$path" &>/dev/null; then
-      fstype="btrfs"
+      fstype=btrfs
     else
-      ERRO '$swapfc_path is located on an unknown filesystem'
+      ERRO "swapfc_path is located on an unknown filesystem"
     fi
   fi
 
-  echo "$fstype"
+  echo $fstype
 }
 AMI_ROOT(){ [ "${UID}" == "0" ] || ERRO "Script must be run as root!"; }
 FIND_SWAP_UNITS(){ find /run/systemd/{system/,generator/} -type f -name "*.swap"; }
@@ -373,10 +373,10 @@ case "$1" in
       FSTYPE=$(get_fs_type "${swapfc_path}")
       # must exists before stat()
       mkdir -p "$(dirname "${swapfc_path}")"
-      if [ "$FSTYPE" = btrfs ]; then
-        btrfs subvolume create "${swapfc_path}" &>/dev/null
+      if [[ "$FSTYPE" == btrfs ]]; then
+        btrfs subvolume create "$swapfc_path" &>/dev/null
       else
-        mkdir -p "${swapfc_path}" 
+        mkdir -p "$swapfc_path" 
       fi
 
       chunk_size=$(to_bytes "${swapfc_chunk_size}")

--- a/systemd-swap
+++ b/systemd-swap
@@ -373,8 +373,11 @@ case "$1" in
       FSTYPE=$(get_fs_type "${swapfc_path}")
       # must exists before stat()
       mkdir -p "$(dirname "${swapfc_path}")"
-      [[ $FSTYPE == btrfs ]] && { btrfs subvolume create "${swapfc_path}" \
-	      || mkdir -p "${swapfc_path}"; }
+      if [ "$FSTYPE" = btrfs ]; then
+        btrfs subvolume create "${swapfc_path}" &>/dev/null
+      else
+        mkdir -p "${swapfc_path}" 
+      fi
 
       chunk_size=$(to_bytes "${swapfc_chunk_size}")
       BLOCK_SIZE=$(stat -f -c %s "${swapfc_path}")


### PR DESCRIPTION
This is a hotfix for the previous pull request that was merged too quickly, resulting in a critical bug on btrfs systems when the script is run for the second time, e.g. after a reboot