### PR TITLE
Dynamically patch paths when installing manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 systemd-swap_*_any*
 swap.conf
+*.new

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,30 @@
-prefix			?= $(PREFIX)
+prefix ?= $(PREFIX)
 
 # this avoids /usr/local/usr/* when
 # installing with prefix=/usr/local
 ifeq ($(prefix), /usr/local)
-exec_prefix		?= $(prefix)
-datarootdir		?= $(prefix)/share
+exec_prefix ?= $(prefix)
+datarootdir ?= $(prefix)/share
 else
-exec_prefix		?= $(prefix)/usr
-datarootdir		?= $(prefix)/usr/share
+exec_prefix ?= $(prefix)/usr
+datarootdir ?= $(prefix)/usr/share
 endif
 
-bindir			?= $(exec_prefix)/bin
-libdir			?= $(exec_prefix)/lib
-datadir			?= $(datarootdir)
-mandir			?= $(datarootdir)/man
+bindir ?= $(exec_prefix)/bin
+libdir ?= $(exec_prefix)/lib
+datadir ?= $(datarootdir)
+mandir ?= $(datarootdir)/man
 
-sysconfdir		?= $(prefix)/etc
-localstatedir	?= $(prefix)/var
+sysconfdir ?= $(prefix)/etc
+localstatedir ?= $(prefix)/var
 
-FEDORA_VERSION 	?= f32
+FEDORA_VERSION ?= f32
+
 GIT := $(shell command -v git 2> /dev/null)
 
-default: help
+ifneq ($(strip $(prefix)),)
+PATCH := true
+endif
 
 LIB_T := $(DESTDIR)$(localstatedir)/lib/systemd-swap
 BIN_T := $(DESTDIR)$(bindir)/systemd-swap
@@ -33,34 +36,59 @@ MAN8_T := $(DESTDIR)$(mandir)/man8/systemd-swap.8
 
 .PHONY: files dirs install uninstall clean deb rpm help
 
+default: help
+
 $(LIB_T):
 	mkdir -p $@
 
 dirs: $(LIB_T)
 
 $(BIN_T): systemd-swap
-	install -Dm755 $< $@
+ifdef PATCH
+	@echo '** Patching prefix in systemd-swap..'
+	@sed -e 's#ETC_SYSD="/etc/systemd"#ETC_SYSD="$(sysconfdir)/systemd"#' \
+		-e 's#VEN_SYSD="/usr/lib/systemd"#VEN_SYSD="$(libdir)/systemd"#' \
+		-e 's#DEF_CONFIG="/usr/share/systemd-swap/swap-default.conf"#DEF_CONFIG="$(datarootdir)/systemd-swap/swap-default.conf"#' \
+	 	$< > systemd-swap.new
+	install -p -Dm755 systemd-swap.new $@
+else
+	install -p -Dm755 $< $@
+endif
 
 $(SVC_T): systemd-swap.service
-	install -Dm644 $< $@
+ifdef PATCH
+	@echo '** Patching prefix in systemd-swap.service..'
+	@sed 's#/usr/bin/systemd-swap#$(bindir)/systemd-swap#g' $< > systemd-swap.service.new
+	install -p -Dm644 systemd-swap.service.new $@
+else
+	install -p -Dm644 $< $@
+endif
 
 $(DFL_T): swap-default.conf
-	install -Dm644 $< $@
+	install -p -Dm644 $< $@
 
 $(CNF_T): swap.conf
-	install -bDm644 -S .old $< $@
+ifdef PATCH
+	@echo '** Patching prefix in swap.conf..'
+	@sed -e 's#/usr/share/systemd-swap/swap-default.conf#$(datarootdir)/systemd-swap/swap-default.conf#g' \
+		$< > swap.conf.new
+	install -p -bDm644 -S .old swap.conf.new $@
+else
+	install -p -bDm644 -S .old $< $@
+endif
 
 $(MAN5_T): man/swap.conf.5
-	install -Dm644 $< $@
+	install -p -Dm644 $< $@
 
 $(MAN8_T): man/systemd-swap.8
-	install -Dm644 $< $@
+	install -p -Dm644 $< $@
 
 define banner
 #  This file is part of systemd-swap.\n#\n# Entries in this file show the systemd-swap defaults as\n# specified in /usr/share/systemd-swap/swap-default.conf\n# You can change settings by editing this file.\n# Defaults can be restored by simply deleting this file.\n#\n# See swap.conf(5) and /usr/share/systemd-swap/swap-default.conf for details.\n\n
 endef
 
 swap.conf: ## Generate swap.conf
+	@echo '** Generating swap.conf..'
 	@printf "$(banner)" > $@
 	@grep -o '^[^#]*' swap-default.conf | sed 's/^/#/;s/[ \t]*$$//' >> $@
 
@@ -78,8 +106,9 @@ uninstall:
 clean: ## Remove generated files
 ifdef GIT
 	git clean -fxd
+else
+	rm -vf swap.conf *.new
 endif
-	rm -vf swap.conf
 
 deb: ## Create debian package
 deb: package.sh

--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,7 @@ $(DFL_T): swap-default.conf
 	install -p -Dm644 $< $@
 
 $(CNF_T): swap.conf
-ifdef PATCH
-	@echo '** Patching prefix in swap.conf..'
-	@sed -e 's#/usr/share/systemd-swap/swap-default.conf#$(datarootdir)/systemd-swap/swap-default.conf#g' \
-		$< > swap.conf.new
-	install -p -bDm644 -S .old swap.conf.new $@
-else
 	install -p -bDm644 -S .old $< $@
-endif
 
 $(MAN5_T): man/swap.conf.5
 	install -p -Dm644 $< $@
@@ -84,7 +77,7 @@ $(MAN8_T): man/systemd-swap.8
 	install -p -Dm644 $< $@
 
 define banner
-#  This file is part of systemd-swap.\n#\n# Entries in this file show the systemd-swap defaults as\n# specified in /usr/share/systemd-swap/swap-default.conf\n# You can change settings by editing this file.\n# Defaults can be restored by simply deleting this file.\n#\n# See swap.conf(5) and /usr/share/systemd-swap/swap-default.conf for details.\n\n
+#  This file is part of systemd-swap.\n#\n# Entries in this file show the systemd-swap defaults as\n# specified in $(datarootdir)/systemd-swap/swap-default.conf\n# You can change settings by editing this file.\n# Defaults can be restored by simply deleting this file.\n#\n# See swap.conf(5) and $(datarootdir)/systemd-swap/swap-default.conf for details.\n\n
 endef
 
 swap.conf: ## Generate swap.conf

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ localstatedir ?= $(prefix)/var
 
 FEDORA_VERSION ?= f32
 
-GIT := $(shell command -v git 2> /dev/null)
+GITB := $(shell command -v git 2>/dev/null)
+ifdef GITB
+REPO := $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
+endif
 
 ifneq ($(strip $(prefix)),)
 PATCH := true
@@ -97,7 +100,7 @@ uninstall:
 	rm -rv $(LIB_T) $(DESTDIR)$(datadir)/systemd-swap
 
 clean: ## Remove generated files
-ifdef GIT
+ifdef REPO
 	git clean -fxd
 else
 	rm -vf swap.conf *.new

--- a/README.md
+++ b/README.md
@@ -31,43 +31,40 @@ sudo systemctl enable --now systemd-swap
 
 - <img src="https://www.monitorix.org/imgs/archlinux.png" weight="16" height="16"> **Arch**: in the [community](https://www.archlinux.org/packages/community/any/systemd-swap/).
 
-- <img src="https://www.monitorix.org/imgs/debian.png" weight="16" height="16"> **Debian**: use [package.sh](https://raw.githubusercontent.com/Nefelim4ag/systemd-swap/master/package.sh)
+- <img src="https://www.monitorix.org/imgs/debian.png" weight="16" height="16"> **Debian**
 
   ```shell
-  git clone https://github.com/Nefelim4ag/systemd-swap.git
-  ./systemd-swap/package.sh debian
-  sudo apt install ./systemd-swap/systemd-swap_*_all.deb
+  git clone --depth=1 https://github.com/Nefelim4ag/systemd-swap.git
+  cd systemd-swap
+  make deb
+  sudo dpkg -i systemd-swap_*_all.deb
   ```
 
 - <img src="https://www.monitorix.org/imgs/fedora.png" weight="16" height="16"> **Fedora**
 
   ```shell
-  git clone https://github.com/Nefelim4ag/systemd-swap.git
-  ./systemd-swap/package.sh fedora f32
-  sudo dnf install ./systemd-swap/systemd-swap-*noarch.rpm
+  git clone --depth=1 https://github.com/Nefelim4ag/systemd-swap.git
+  cd systemd-swap
+  FEDORA_VERSION=f32 make rpm
+  sudo rpm -U systemd-swap-*noarch.rpm
   ```
 
-- <img src="https://www.monitorix.org/imgs/centos.png" weight="16" height="16"> **CentOS7**:
+- <img src="https://www.monitorix.org/imgs/centos.png" weight="16" height="16"> **CentOS**
 
   ```shell
-  git clone https://github.com/Nefelim4ag/systemd-swap.git
+  git clone --depth=1 https://github.com/Nefelim4ag/systemd-swap.git
   ./systemd-swap/package.sh centos
-  sudo yum install ./systemd-swap/systemd-swap-*noarch.rpm
-  ```
-
-- <img src="https://www.monitorix.org/imgs/centos.png" weight="16" height="16"> **CentOS8**:
-
-  ```shell
-  git clone https://github.com/Nefelim4ag/systemd-swap.git
-  ./systemd-swap/package.sh centos
-  sudo dnf install ./systemd-swap/systemd-swap-*noarch.rpm
+  sudo rpm -U ./systemd-swap/systemd-swap-*noarch.rpm
   ```
 
 - **Manual**
 
   ```shell
-  git clone https://github.com/Nefelim4ag/systemd-swap.git
+  git clone --depth=1 https://github.com/Nefelim4ag/systemd-swap.git
   sudo make install
+
+  # or into /usr/local:
+  sudo make prefix=/usr/local install
   ```
 
 ## About configuration

--- a/package.sh
+++ b/package.sh
@@ -13,7 +13,7 @@ debian_package(){
   [ -z "${VERSION}" ] && ERRO "Can't get git tag, VERSION are empty!"
   DEB_NAME="systemd-swap_${VERSION}_all"
   mkdir -p "${DEB_NAME}"
-  make install PREFIX="${DEB_NAME}/"
+  DESTDIR=${DEB_NAME}/ make install
   mkdir -p  "${DEB_NAME}/DEBIAN"
   chmod 755 "${DEB_NAME}/DEBIAN"
   {

--- a/package.sh
+++ b/package.sh
@@ -13,7 +13,7 @@ debian_package(){
   [ -z "${VERSION}" ] && ERRO "Can't get git tag, VERSION are empty!"
   DEB_NAME="systemd-swap_${VERSION}_all"
   mkdir -p "${DEB_NAME}"
-  DESTDIR=${DEB_NAME}/ make install
+  DESTDIR="${DEB_NAME}"/ make install
   mkdir -p  "${DEB_NAME}/DEBIAN"
   chmod 755 "${DEB_NAME}/DEBIAN"
   {
@@ -43,7 +43,7 @@ centos_package(){
   test -d ./build && rm -rf ./build
   mkdir -p ./build/BUILD
   find . -type f ! -path './.git/*' ! -path './build/*' -exec cp {} build/BUILD \;
-  rpmbuild --define "_topdir `pwd`/build" -bb systemd-swap.spec
+  rpmbuild --define "_topdir $(pwd)/build" -bb systemd-swap.spec
   mv build/RPMS/noarch/*.rpm ./
   rm -rf ./build
 }


### PR DESCRIPTION
This is a proposal to address https://github.com/Nefelim4ag/systemd-swap/issues/133 and solve the path issues.

It patches files dynamically at install and embeds the new paths, which are derived from `prefix`.

Because of this, there is a regression when building distribution packages as most of the build files, e.g. [Arch's official PKGFILE](https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/systemd-swap), use `PREFIX` instead of the recommended [`DESTDIR`](https://www.gnu.org/prep/standards/html_node/DESTDIR.html) (because of the *old* Makefile not supporting this, I guess).

The bundled ways of building the packages should fully support this method, though I did not test CentOS.

If this is too ugly, ignore it - but I couldn't come up with a better way, and while I didn't run into any issues, it needs some more testing.