### PR TITLE
Zram: If "Device or resource busy", retry exec zramctl

### DIFF
--- a/systemd-swap
+++ b/systemd-swap
@@ -670,7 +670,8 @@ def start() -> None:
                         "modprobe rule"
                     )
                 new_zram = read("/sys/class/zram-control/hot_add").rstrip()
-                info(f"Zram: success: new device /dev/zram{new_zram}")
+                zram_dev = f"/dev/zram{new_zram}"
+                info(f"Zram: success: new device {zram_dev}")
             elif "/dev/zram" in output:
                 mode = os.stat(output).st_mode
                 if not stat.S_ISBLK(mode):

--- a/systemd-swap
+++ b/systemd-swap
@@ -628,9 +628,13 @@ def start() -> None:
         zram_size = round(config.get("zram_size", int) / config.get("zram_count", int))
         for _ in range(config.get("zram_count", int)):
             info("Zram: trying to initialize free device")
-            # zramctl is an external program -> return path to first free device.
             output = None
-            for n in range(2):
+            success = False
+            for n in range(3):
+                if n > 0:
+                    warn(f"Zram: device or resource was busy, retry #{n}")
+                    time.sleep(1)
+                # zramctl is an external program -> return path to first free device.
                 output = subprocess.run(
                     [
                         "zramctl",
@@ -647,10 +651,14 @@ def start() -> None:
                     stderr=subprocess.STDOUT,
                 ).stdout.rstrip()
                 if "failed to reset: Device or resource busy" in output:
-                    time.sleep(1)
                     continue
                 else:
+                    success = True
                     break
+            # Try limit reached.
+            if not success:
+                warn("Zram: device or resource was busy too many times")
+                continue
             zram_dev = None
             if "zramctl: no free zram device found" in output:
                 warn("Zram: zramctl can't find free device")

--- a/systemd-swap
+++ b/systemd-swap
@@ -629,25 +629,30 @@ def start() -> None:
         for _ in range(config.get("zram_count", int)):
             info("Zram: trying to initialize free device")
             # zramctl is an external program -> return path to first free device.
-            output = subprocess.run(
-                [
-                    "zramctl",
-                    "-f",
-                    "-a",
-                    config.get("zram_alg"),
-                    "-t",
-                    config.get("zram_streams"),
-                    "-s",
-                    str(zram_size),
-                ],
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-            ).stdout.rstrip()
+            output = None
+            for n in range(2):
+                output = subprocess.run(
+                    [
+                        "zramctl",
+                        "-f",
+                        "-a",
+                        config.get("zram_alg"),
+                        "-t",
+                        config.get("zram_streams"),
+                        "-s",
+                        str(zram_size),
+                    ],
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                ).stdout.rstrip()
+                if "failed to reset: Device or resource busy" in output:
+                    time.sleep(1)
+                    continue
+                else:
+                    break
             zram_dev = None
-            if "failed to reset: Device or resource busy" in output:
-                time.sleep(1)
-            elif "zramctl: no free zram device found" in output:
+            if "zramctl: no free zram device found" in output:
                 warn("Zram: zramctl can't find free device")
                 info("Zram: using workaround hook for hot add")
                 if not os.path.isfile("/sys/class/zram-control/hot_add"):


### PR DESCRIPTION
Sometimes, systemd-swap produced error: **TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType**

The cause is:
 If zramctl returned "failed to reset: Device or resource busy", systemd-swap just sleep 1 second but not retry exec zramctl.

So I change some code to retry exec zramctl when things happen.

The log:
```
systemd-swap[643]: INFO: Removing working directory...
systemd-swap[643]: INFO: Removing files in /var/lib/systemd-swap/swapfc/...
systemd-swap[643]: WARN: Combining zram with zswap/swapfc/swapd_auto_swapon can lead to LRU inversion and is strongly recommended against
systemd-swap[643]: INFO: Zram: check availability
systemd-swap[643]: INFO: Zram: not part of kernel, trying to find zram module
systemd-swap[643]: INFO: Zram: module successfully loaded
systemd-swap[643]: INFO: Zram: trying to initialize free device
systemd-swap[643]: Traceback (most recent call last):
systemd-swap[643]:   File "/usr/bin/systemd-swap", line 904, in <module>
systemd-swap[643]:     main()
systemd-swap[643]:   File "/usr/bin/systemd-swap", line 892, in main
systemd-swap[643]:     start()
systemd-swap[643]:   File "/usr/bin/systemd-swap", line 666, in start
systemd-swap[643]:     mode = os.stat(zram_dev).st_mode
systemd-swap[643]: TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType

```