### PR TITLE
Fix Systemd Service

### DIFF
--- a/include/systemd-swap.service
+++ b/include/systemd-swap.service
@@ -24,7 +24,6 @@ PrivateTmp=yes
 ProtectControlGroups=yes
 ProtectHome=read-only
 ProtectHostname=yes
-ProtectProc=invisible
 ProtectSystem=full
 RestrictNamespaces=yes
 RestrictSUIDSGID=yes


### PR DESCRIPTION
The "ProtectProc=" option causes some warnings on Ubuntu systems, and apparently doesn't interfere with the functioning.