### PR TITLE
zswap.zpool: z3fold is now deprecated and zbud could have the same faith in the near future, better handle this change

### DIFF
--- a/include/swap-default.conf
+++ b/include/swap-default.conf
@@ -17,7 +17,7 @@
 zswap_enabled=1
 zswap_compressor=zstd     # lzo lz4 zstd lzo-rle lz4hc
 zswap_max_pool_percent=25 # 1-99
-zswap_zpool=z3fold        # zbud z3fold (note z3fold requires kernel 4.8+)
+zswap_zpool=zsmalloc        # zbud z3fold (note z3fold requires kernel 4.8+, deprecated since 6.12) zsmalloc
 
 ################################################################################
 # ZRam

--- a/include/systemd-swap.service
+++ b/include/systemd-swap.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Manage swap spaces on zram, files and partitions.
-Wants=modprobe@zram.service
-After=modprobe@zram.service
+Wants=modprobe@zram.service modprobe@z3fold.service modprobe@zbud.service
+After=modprobe@zram.service modprobe@z3fold.service modprobe@zbud.service
 
 [Service]
 Type=notify

--- a/man/swap.conf.5
+++ b/man/swap.conf.5
@@ -49,7 +49,7 @@ and
 Percentage of ram that can be compressed.
 .I
 .IP zswap_zpool=
-Set wich compressed memory pool to use, if unsure use z3fold.
+Set wich compressed memory pool to use, if unsure use zsmalloc.
 .PP
 The following options are available in the "zram" section:
 .I

--- a/src/systemd-swap.py
+++ b/src/systemd-swap.py
@@ -423,8 +423,8 @@ class SwapFc:
 
     @staticmethod
     def get_free_ram_perc() -> int:
-        ram_stats = get_mem_stats(["MemTotal", "MemFree"])
-        return round((ram_stats["MemFree"] * 100) / ram_stats["MemTotal"])
+        ram_stats = get_mem_stats(["MemTotal", "MemAvailable"])
+        return round((ram_stats["MemAvailable"] * 100) / ram_stats["MemTotal"])
 
     @staticmethod
     def get_free_swap_perc() -> int:

--- a/src/systemd-swap.py
+++ b/src/systemd-swap.py
@@ -471,8 +471,11 @@ def relative_symlink(target: str, link_name: str) -> None:
 
 
 def write(data: str, file: str) -> None:
-    with open(file, "w") as f:
-        f.write(data)
+    try:
+        with open(file, "w") as f:
+            f.write(data)
+    except:
+        warn(f"Failed writing {data} to file {file}")
 
 
 def read(file: str) -> str:

--- a/src/systemd-swap.py
+++ b/src/systemd-swap.py
@@ -37,7 +37,7 @@ def get_mem_stats(fields: List[str]) -> Dict[str, int]:
                 stats[key] = int(items[1]) * 1024
             if not fields:
                 break
-    assert len(fields) == 0
+    assert len(fields) <= 1
     return stats
 
 
@@ -423,8 +423,12 @@ class SwapFc:
 
     @staticmethod
     def get_free_ram_perc() -> int:
-        ram_stats = get_mem_stats(["MemTotal", "MemAvailable"])
-        return round((ram_stats["MemAvailable"] * 100) / ram_stats["MemTotal"])
+        ram_stats = get_mem_stats(["MemTotal", "MemFree", "MemAvailable"])
+        if "MemAvailable" in ram_stats:
+            free_ram = ram_stats["MemAvailable"]
+        else:
+            free_ram = ram_stats["MemFree"]
+        return round((free_ram * 100) / ram_stats["MemTotal"])
 
     @staticmethod
     def get_free_swap_perc() -> int:


### PR DESCRIPTION
By default, z3fold is not built anymore since it has been deprecated in kernel 6.12. Zbud could have the same faith in the near future. The default allocator is zsmalloc and is always available when Zswap is enabled.
N.B.: A new allocator is in the work that will need to be added in the near future.

Default to zsmalloc if unsure or if the module for the requested Zpool allocator is not available and inform the user about it.

I also pushed an improvement for estimating available free memory by using MemAvailable instead of MemFree. This commit (afb82b4) could have been in a different PR, but it was taken in the series.

